### PR TITLE
fix: Add null guards for .NET Framework MSBuild compatibility

### DIFF
--- a/src/JD.Efcpt.Build.Tasks/Chains/ConnectionStringResolutionChain.cs
+++ b/src/JD.Efcpt.Build.Tasks/Chains/ConnectionStringResolutionChain.cs
@@ -99,11 +99,23 @@ internal static class ConnectionStringResolutionChain
     }
 
     private static bool HasAppSettingsFiles(string projectDirectory)
-        => Directory.GetFiles(projectDirectory, "appsettings*.json").Length > 0;
+    {
+        // Guard against null - can occur on .NET Framework MSBuild
+        if (string.IsNullOrWhiteSpace(projectDirectory) || !Directory.Exists(projectDirectory))
+            return false;
+
+        return Directory.GetFiles(projectDirectory, "appsettings*.json").Length > 0;
+    }
 
     private static bool HasAppConfigFiles(string projectDirectory)
-        => File.Exists(Path.Combine(projectDirectory, "app.config")) ||
-           File.Exists(Path.Combine(projectDirectory, "web.config"));
+    {
+        // Guard against null - can occur on .NET Framework MSBuild
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+            return false;
+
+        return File.Exists(Path.Combine(projectDirectory, "app.config")) ||
+               File.Exists(Path.Combine(projectDirectory, "web.config"));
+    }
 
     #endregion
 
@@ -130,6 +142,10 @@ internal static class ConnectionStringResolutionChain
         string connectionStringName,
         BuildLog log)
     {
+        // Guard against null - can occur on .NET Framework MSBuild
+        if (string.IsNullOrWhiteSpace(projectDirectory) || !Directory.Exists(projectDirectory))
+            return null;
+
         var appSettingsFiles = Directory.GetFiles(projectDirectory, "appsettings*.json");
 
         if (appSettingsFiles.Length > 1)
@@ -158,6 +174,10 @@ internal static class ConnectionStringResolutionChain
         string connectionStringName,
         BuildLog log)
     {
+        // Guard against null - can occur on .NET Framework MSBuild
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+            return null;
+
         var configFiles = new[] { "app.config", "web.config" };
         foreach (var configFile in configFiles)
         {

--- a/src/JD.Efcpt.Build.Tasks/Chains/ResourceResolutionChain.cs
+++ b/src/JD.Efcpt.Build.Tasks/Chains/ResourceResolutionChain.cs
@@ -70,8 +70,9 @@ internal static class ResourceResolutionChain
                 : throw overrideNotFound($"Override not found: {path}", path);
         }
 
-        // Branch 2: Search project directory
-        if (TryFindInDirectory(context.ProjectDirectory, context.ResourceNames, exists, out var found))
+        // Branch 2: Search project directory (if provided)
+        if (!string.IsNullOrWhiteSpace(context.ProjectDirectory) &&
+            TryFindInDirectory(context.ProjectDirectory, context.ResourceNames, exists, out var found))
             return found;
 
         // Branch 3: Search solution directory (if enabled)
@@ -99,6 +100,13 @@ internal static class ResourceResolutionChain
         ExistsPredicate exists,
         out string foundPath)
     {
+        // Guard against null inputs - can occur on .NET Framework MSBuild
+        if (string.IsNullOrWhiteSpace(directory) || resourceNames == null || resourceNames.Count == 0)
+        {
+            foundPath = string.Empty;
+            return false;
+        }
+
         var matchingCandidate = resourceNames
             .Select(name => Path.Combine(directory, name))
             .FirstOrDefault(candidate => exists(candidate));

--- a/src/JD.Efcpt.Build.Tasks/PathUtils.cs
+++ b/src/JD.Efcpt.Build.Tasks/PathUtils.cs
@@ -3,17 +3,26 @@ namespace JD.Efcpt.Build.Tasks;
 internal static class PathUtils
 {
     public static string FullPath(string path, string baseDir)
-        => string.IsNullOrWhiteSpace(path)
-            ? path
-            : Path.GetFullPath(Path.IsPathRooted(path)
-                ? path
-                : Path.Combine(baseDir, path));
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return path;
+
+        if (Path.IsPathRooted(path))
+            return Path.GetFullPath(path);
+
+        // Handle null/empty baseDir by using current directory
+        // This can happen when MSBuild sets properties to null on .NET Framework
+        if (string.IsNullOrWhiteSpace(baseDir))
+            return Path.GetFullPath(path);
+
+        return Path.GetFullPath(Path.Combine(baseDir, path));
+    }
 
     public static bool HasValue(string? s) => !string.IsNullOrWhiteSpace(s);
 
     public static bool HasExplicitPath(string? s)
         => !string.IsNullOrWhiteSpace(s)
-           && (Path.IsPathRooted(s) 
-               || s.Contains(Path.DirectorySeparatorChar) 
+           && (Path.IsPathRooted(s)
+               || s.Contains(Path.DirectorySeparatorChar)
                || s.Contains(Path.AltDirectorySeparatorChar));
 }

--- a/src/JD.Efcpt.Build.Tasks/ResolveSqlProjAndInputs.cs
+++ b/src/JD.Efcpt.Build.Tasks/ResolveSqlProjAndInputs.cs
@@ -450,7 +450,11 @@ public sealed class ResolveSqlProjAndInputs : Task
 
     private string ResolveSqlProjWithValidation(BuildLog log)
     {
-        var sqlRefs = ProjectReferences
+        // ProjectReferences may be null on some .NET Framework MSBuild hosts
+        var references = ProjectReferences ?? [];
+
+        var sqlRefs = references
+            .Where(x => x?.ItemSpec != null)
             .Select(x => PathUtils.FullPath(x.ItemSpec, ProjectDirectory))
             .Where(SqlProjectDetector.IsSqlProjectReference)
             .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
On .NET Framework MSBuild hosts, certain properties like ProjectDirectory, ProjectReferences, and other MSBuild-set values may be null instead of empty strings. This caused NullReferenceExceptions in:

- PathUtils.FullPath when baseDir was null
- ResolveSqlProjWithValidation when ProjectReferences or ItemSpec was null
- ResourceResolutionChain when searching directories with null paths
- ConnectionStringResolutionChain when checking for config files with null directory

This fix adds defensive null checks to handle these edge cases, ensuring the build works correctly on both .NET Framework and .NET Core MSBuild hosts.