### PR TITLE
feat: enable NuGet version checking by default for SDK users (#31)

### DIFF
--- a/src/JD.Efcpt.Sdk/build/JD.Efcpt.Sdk.props
+++ b/src/JD.Efcpt.Sdk/build/JD.Efcpt.Sdk.props
@@ -21,7 +21,7 @@
       This helps ensure SDK users are always aware of updates.
       Users can still opt-out by setting EfcptCheckForUpdates=false in their project.
     -->
-    <EfcptCheckForUpdates Condition="'$(EfcptCheckForUpdates)'==''">true</EfcptCheckForUpdates>
+    <EfcptCheckForUpdates Condition="'$(EfcptCheckForUpdates)' == ''">true</EfcptCheckForUpdates>
   </PropertyGroup>
 
   <!-- Import SDK version for update check feature -->


### PR DESCRIPTION
SDK-based projects (those using JD.Efcpt.Sdk) will now automatically check for new SDK versions on build. This helps ensure SDK users are always aware when updates are available.

Users can still opt-out by setting EfcptCheckForUpdates=false in their project file.