### PR TITLE
fix: pin System.Security.Cryptography.Xml to safe version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Snowflake.Data" Version="5.4.1" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.5" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.15" />
     <PackageVersion Include="Testcontainers.FirebirdSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />

--- a/tests/TestAssets/SampleApp/Sample.App.csproj
+++ b/tests/TestAssets/SampleApp/Sample.App.csproj
@@ -28,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <Import Project="$(EfcptBuildRoot)JD.Efcpt.Build.targets" />


### PR DESCRIPTION
Fixes NU1903 during PR-only restore by pinning System.Security.Cryptography.Xml to 9.0.15 and referencing it from the sample test asset so Dependabot updates can restore successfully.