### PR TITLE
chore: harden grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,13 @@
+# Keep dependency PRs grouped and delayed for at least 48 hours so newly published packages age before adoption.
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore(deps)"
-    cooldown:
-      default-days: 2
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -29,6 +17,25 @@ updates:
     cooldown:
       default-days: 2
     groups:
-      all-dependencies:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 2
+    groups:
+      nuget-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
Standardizes grouped Dependabot updates with a 48-hour cooldown before version update PRs.