### PR TITLE
ci: add weekly efcpt compatibility matrix

### DIFF
--- a/.github/workflows/efcpt-compat.yml
+++ b/.github/workflows/efcpt-compat.yml
@@ -1,0 +1,172 @@
+name: EFCPT Compatibility Matrix
+
+# Guards against upstream ErikEJ.EFCorePowerTools.Cli (efcpt) releases silently
+# breaking this package. efcpt releases are pinned to EF Core version lines and can
+# introduce breaking changes without warning. This job weekly resolves the latest
+# efcpt release per supported EF Core line and rebuilds a representative sample that
+# actually invokes efcpt, failing loudly (with a job summary) when a version breaks.
+
+on:
+  schedule:
+    # Weekly, Monday 07:00 UTC
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual run'
+        required: false
+        default: 'Manual efcpt compatibility check'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "efcpt-compat-${{ github.ref }}"
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  EFCPT_PACKAGE_ID: ErikEJ.EFCorePowerTools.Cli
+  # Space-separated EF Core major lines this package supports/tests (see docs/user-guide/efcpt-compatibility.md).
+  # efcpt CLI release lines track EF Core: 8.x -> EF Core 8, 9.x -> EF Core 9, 10.x -> EF Core 10.
+  EFCPT_SUPPORTED_LINES: "8 9 10"
+  # Local pack version high enough to win over any released JD.Efcpt.Build on nuget.org for Version="*".
+  LOCAL_PACKAGE_VERSION: "99.0.0"
+
+jobs:
+  resolve-versions:
+    name: Resolve latest efcpt per EF Core line
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+    steps:
+      - name: Query nuget.org for latest efcpt version per supported line
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          INDEX="https://api.nuget.org/v3-flatcontainer/erikej.efcorepowertools.cli/index.json"
+          echo "Fetching $INDEX"
+          ALL="$(curl -fsSL "$INDEX" | jq -r '.versions[]')"
+
+          include='[]'
+          for line in $EFCPT_SUPPORTED_LINES; do
+            # Latest STABLE (no pre-release marker) version whose major component == line.
+            latest="$(printf '%s\n' "$ALL" \
+              | grep -E "^${line}\." \
+              | grep -viE '-' \
+              | sort -V \
+              | tail -n1 || true)"
+            if [ -z "$latest" ]; then
+              echo "::warning::No stable efcpt release found for EF Core line ${line}"
+              continue
+            fi
+            echo "EF Core ${line} -> efcpt ${latest}"
+            include="$(printf '%s' "$include" | jq -c --arg l "$line" --arg v "$latest" '. + [{"efcore":$l,"efcptVersion":$v}]')"
+          done
+
+          if [ "$(printf '%s' "$include" | jq 'length')" -eq 0 ]; then
+            echo "::error::Could not resolve any efcpt versions from nuget.org"
+            exit 1
+          fi
+
+          echo "matrix={\"include\":${include}}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Resolved efcpt versions"
+            echo ""
+            echo "| EF Core line | Latest efcpt (stable) |"
+            echo "| --- | --- |"
+            printf '%s' "$include" | jq -r '.[] | "| \(.efcore) | \(.efcptVersion) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  compat:
+    name: efcpt ${{ matrix.efcptVersion }} (EF Core ${{ matrix.efcore }})
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-versions.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Pack JD.Efcpt.Build to local feed
+        run: |
+          dotnet restore JD.Efcpt.Build.sln --use-lock-file
+          dotnet pack src/JD.Efcpt.Build/JD.Efcpt.Build.csproj \
+            --configuration Release \
+            --output ./artifacts \
+            /p:Version=${{ env.LOCAL_PACKAGE_VERSION }} \
+            /p:PackageVersion=${{ env.LOCAL_PACKAGE_VERSION }}
+
+      - name: Install efcpt ${{ matrix.efcptVersion }}
+        run: |
+          dotnet tool install --global "$EFCPT_PACKAGE_ID" --version "${{ matrix.efcptVersion }}"
+          echo "${HOME}/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Build representative sample against efcpt ${{ matrix.efcptVersion }}
+        id: sample
+        shell: bash
+        run: |
+          set -o pipefail
+          EFCPT_EXE="${HOME}/.dotnet/tools/efcpt"
+          LOG="efcpt-compat-${{ matrix.efcptVersion }}.log"
+          echo "log=$LOG" >> "$GITHUB_OUTPUT"
+
+          # Pin the exact efcpt build via EfcptToolPath: this takes the explicit-path branch in the
+          # RunEfcpt task and bypasses dnx (which would otherwise ignore EfcptToolVersion on .NET 10).
+          set +e
+          dotnet build samples/simple-generation/SimpleGenerationSample.sln \
+            --configuration Release \
+            /p:EfcptToolPath="$EFCPT_EXE" \
+            /p:EfcptToolVersion="${{ matrix.efcptVersion }}" \
+            /p:EfcptLogVerbosity=detailed \
+            2>&1 | tee "$LOG"
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Report incompatibility
+        if: failure() && steps.sample.outputs.rc != '0'
+        shell: bash
+        run: |
+          LOG="${{ steps.sample.outputs.log }}"
+          {
+            echo "## :x: efcpt ${{ matrix.efcptVersion }} (EF Core ${{ matrix.efcore }}) is INCOMPATIBLE"
+            echo ""
+            echo "The representative sample \`samples/simple-generation\` failed to build when scaffolded"
+            echo "with efcpt \`${{ matrix.efcptVersion }}\`. This likely indicates an upstream breaking change."
+            echo ""
+            echo "### Build error excerpt"
+            echo '```'
+            if [ -f "$LOG" ]; then
+              grep -iE 'error|efcpt|exception|EFCPT[0-9]' "$LOG" | tail -n 40 || tail -n 40 "$LOG"
+            else
+              echo "(build log not captured)"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report compatibility
+        if: success()
+        run: |
+          echo "## :white_check_mark: efcpt ${{ matrix.efcptVersion }} (EF Core ${{ matrix.efcore }}) is compatible" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: efcpt-compat-log-${{ matrix.efcore }}-${{ matrix.efcptVersion }}
+          path: ${{ steps.sample.outputs.log }}
+          if-no-files-found: ignore

--- a/docs/user-guide/ci-cd.md
+++ b/docs/user-guide/ci-cd.md
@@ -497,8 +497,13 @@ Enable caching for the efcpt intermediate directory to skip regeneration when sc
 5. **Use environment variables** for connection strings
 6. **Never commit credentials** to source control
 
+## efcpt Compatibility
+
+The `efcpt` CLI is an external tool whose release lines track EF Core versions, so an upstream release can change scaffolding behavior. A scheduled workflow guards against this by weekly rebuilding a sample against the latest `efcpt` per supported EF Core line. See [efcpt Compatibility](efcpt-compatibility.md) for the supported version matrix and how the guard works.
+
 ## Next Steps
 
+- [efcpt Compatibility](efcpt-compatibility.md) - Supported efcpt versions and the weekly compat guard
 - [Troubleshooting](troubleshooting.md) - Solve common problems
 - [Configuration](configuration.md) - Complete configuration reference
 - [Advanced Topics](advanced.md) - Complex scenarios

--- a/docs/user-guide/efcpt-compatibility.md
+++ b/docs/user-guide/efcpt-compatibility.md
@@ -1,0 +1,50 @@
+# efcpt Compatibility
+
+JD.Efcpt.Build wraps the [ErikEJ.EFCorePowerTools.Cli](https://www.nuget.org/packages/ErikEJ.EFCorePowerTools.Cli) (`efcpt`) dotnet tool to scaffold EF Core models at build time. Because `efcpt` is an external tool whose release lines track EF Core versions, a new upstream release can change or break scaffolding behavior without notice. This page documents which `efcpt` versions are supported and how the project continuously guards against regressions.
+
+## Supported versions
+
+`efcpt` CLI release lines map directly to EF Core major versions:
+
+| efcpt line | EF Core line | Target frameworks | Status |
+| --- | --- | --- | --- |
+| `8.x` | EF Core 8 | `net8.0` | Supported |
+| `9.x` | EF Core 9 | `net9.0` | Supported |
+| `10.x` | EF Core 10 | `net10.0` | Supported (default) |
+| `7.x` and earlier | EF Core 7- | `net7.0` | Not tested (end of life) |
+
+The default pin is `<EfcptToolVersion>10.*</EfcptToolVersion>`. On .NET 10+ the CLI is executed via `dnx` with no installation required; on .NET 8/9 it must be installed as a global or manifest tool (see [Getting Started](getting-started.md)). The `10.x` CLI line is backward compatible and can scaffold EF Core 8/9/10 projects, so most consumers should stay on `10.*` regardless of their target framework.
+
+## Pinning a specific version
+
+Override the tool version per project:
+
+```xml
+<PropertyGroup>
+  <EfcptToolVersion>10.*</EfcptToolVersion>
+</PropertyGroup>
+```
+
+> **Note:** On .NET 10+, generation runs through `dnx`, which resolves the tool package independently of `EfcptToolVersion`. To force an exact build (for example, to reproduce a specific version), set `EfcptToolPath` to an installed `efcpt` executable — this bypasses `dnx` and uses that binary directly.
+
+## Weekly compatibility matrix
+
+The repository runs a scheduled GitHub Actions workflow, [`efcpt-compat.yml`](https://github.com/jerrettdavis/JD.Efcpt.Build/blob/main/.github/workflows/efcpt-compat.yml), that detects when a newly released `efcpt` version breaks the package:
+
+1. **Resolve** — Queries the nuget.org [flat-container index](https://api.nuget.org/v3-flatcontainer/erikej.efcorepowertools.cli/index.json) for the latest *stable* `efcpt` release in each supported EF Core line (`8`, `9`, `10`).
+2. **Build** — For each resolved version, packs the local `JD.Efcpt.Build` package into a local feed, installs that exact `efcpt` version as a global tool, and rebuilds the representative sample `samples/simple-generation` (a database-first `net10.0` / EF Core 10 project that scaffolds offline from a `.sqlproj` / DACPAC). The exact version is pinned via `EfcptToolPath` so `dnx` cannot substitute a different build.
+3. **Report** — Each matrix leg runs independently (`fail-fast: false`). A failing leg writes a job summary naming the incompatible `efcpt` version and an excerpt of the build error, so a breaking upstream release is surfaced loudly rather than silently.
+
+The workflow runs weekly (Mondays 07:00 UTC) and can be triggered manually via **workflow_dispatch**.
+
+### Adjusting the tested lines
+
+The set of tested EF Core lines is controlled by the `EFCPT_SUPPORTED_LINES` environment variable in the workflow (default `"8 9 10"`). Add or remove a major line there when the support matrix changes.
+
+## Reacting to a failure
+
+When the compat matrix reports an incompatible version:
+
+1. Review the job summary and uploaded build log to identify the failing `efcpt` version and error.
+2. Reproduce locally by installing that version and building the sample with `EfcptToolPath` pinned.
+3. If the break is legitimate, pin consumers to the last known-good line (for example `<EfcptToolVersion>10.1.*</EfcptToolVersion>`) and track the upstream change before widening the range again.

--- a/docs/user-guide/toc.yml
+++ b/docs/user-guide/toc.yml
@@ -14,6 +14,8 @@
   href: t4-templates.md
 - name: CI/CD Integration
   href: ci-cd.md
+- name: efcpt Compatibility
+  href: efcpt-compatibility.md
 - name: Split Outputs
   href: split-outputs.md
 - name: Advanced Topics


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that continuously detects when a new upstream `ErikEJ.EFCorePowerTools.Cli` (efcpt) release breaks this package. Today there is no CI coverage for this risk — efcpt release lines are pinned to EF Core versions and can introduce breaking changes without warning.

## What it does

`.github/workflows/efcpt-compat.yml` (weekly Mon 07:00 UTC + `workflow_dispatch`):

1. **resolve-versions** — queries the nuget.org flat-container index for the latest *stable* efcpt release per supported EF Core line (`8`, `9`, `10`; configurable via `EFCPT_SUPPORTED_LINES`) and emits a matrix.
2. **compat** (matrix, `fail-fast: false`) — packs `JD.Efcpt.Build` to a local feed, installs each resolved efcpt version, and rebuilds the representative sample `samples/simple-generation` (net10 / EF Core 10, database-first offline `.sqlproj`). The exact version is pinned via **`EfcptToolPath`** so `dnx` cannot substitute a different build (on .NET 10 `dnx` ignores `EfcptToolVersion`).
3. On any failing leg, writes a `$GITHUB_STEP_SUMMARY` naming the incompatible efcpt version with a build-error excerpt, and uploads the build log.

## Files changed

- `.github/workflows/efcpt-compat.yml` — new workflow (validated with `actionlint`)
- `docs/user-guide/efcpt-compatibility.md` — new policy/doc page
- `docs/user-guide/toc.yml`, `docs/user-guide/ci-cd.md` — link the new page

## Notes

- **No MSBuild changes required** — the package already exposes `EfcptToolVersion` (default `10.*`) and `EfcptToolPath`. The workflow reuses `EfcptToolPath` to hard-pin each version.
- Supported lines confirmed as EF Core 8/9/10 from the README/docs (v7 is EOL, not tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)