### PR TITLE
fix(msbuild): skip pipeline during design-time builds

### DIFF
--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -273,6 +273,7 @@ Applies MSBuild property overrides to the staged `efcpt-config.json` file. This 
 | Property | Default | Description |
 |----------|---------|-------------|
 | `EfcptEnabled` | `true` | Master switch for the entire pipeline |
+| `EfcptRunDuringDesignTimeBuild` | `false` | Force the pipeline to run during IDE design-time builds (`DesignTimeBuild=true`). Off by default so tool restore/SDK checks/efcpt never fire on IntelliSense builds. |
 | `EfcptSqlProj` | *(auto-discovered)* | Path to `.sqlproj` file |
 | `EfcptDacpac` | *(empty)* | Path to pre-built `.dacpac` file (skips .sqlproj build) |
 | `EfcptConfig` | `efcpt-config.json` | EF Core Power Tools configuration |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -19,6 +19,7 @@ Set these properties in your `.csproj` file or `Directory.Build.props`.
 | Property | Default | Description |
 |----------|---------|-------------|
 | `EfcptEnabled` | `true` | Master switch for the entire pipeline |
+| `EfcptRunDuringDesignTimeBuild` | `false` | Allow the pipeline to run during IDE design-time builds (IntelliSense). By default the pipeline is skipped whenever MSBuild sets `DesignTimeBuild=true`, so tool restore/SDK checks/efcpt invocation never fire on every keystroke or file-open in Visual Studio/Rider. Set to `true` to force generation during design-time builds. |
 | `EfcptSqlProj` | *(auto-discovered)* | Path to SQL Project file (`.sqlproj` for Microsoft.Build.Sql, `.csproj`/`.fsproj` for MSBuild.Sdk.SqlProj) |
 | `EfcptDacpac` | *(empty)* | Path to pre-built `.dacpac` file (skips SQL Project build) |
 | `EfcptConfig` | `efcpt-config.json` | EF Core Power Tools configuration file |

--- a/src/JD.Efcpt.Build.Definitions/BuildTransitivePropsFactory.cs
+++ b/src/JD.Efcpt.Build.Definitions/BuildTransitivePropsFactory.cs
@@ -17,6 +17,12 @@ public static class BuildTransitivePropsFactory
                 p.PropertyGroup(null, group =>
                 {
                     group.Property<EfcptEnabled>( "true", "'$(EfcptEnabled)'==''");
+                    // Design-Time Build Guard: default for the opt-back-in override. The actual
+                    // guard that forces EfcptEnabled=false during a design-time build lives in
+                    // BuildTransitiveTargetsFactory (JD.Efcpt.Build.targets), not here, because
+                    // this props file is imported before the consuming project's own
+                    // PropertyGroup - too early to see a project-level override of this property.
+                    group.Property<EfcptRunDuringDesignTimeBuild>( "false", "'$(EfcptRunDuringDesignTimeBuild)'==''");
                     group.Property<EfcptOutput>( "$(BaseIntermediateOutputPath)efcpt\\", "'$(EfcptOutput)'==''");
                     group.Property<EfcptGeneratedDir>( "$(EfcptOutput)Generated\\", "'$(EfcptGeneratedDir)'==''");
                     group.Property<EfcptSqlProj>( "", "'$(EfcptSqlProj)'==''");
@@ -112,6 +118,7 @@ public static class BuildTransitivePropsFactory
                 t.PropertyGroup(null, group =>
                 {
                     group.Property<EfcptEnabled>( "true", "'$(EfcptEnabled)'==''");
+                    group.Property<EfcptRunDuringDesignTimeBuild>( "false", "'$(EfcptRunDuringDesignTimeBuild)'==''");
                     group.Property<EfcptOutput>( "$(BaseIntermediateOutputPath)efcpt\\", "'$(EfcptOutput)'==''");
                     group.Property<EfcptGeneratedDir>( "$(EfcptOutput)Generated\\", "'$(EfcptGeneratedDir)'==''");
                     group.Property<EfcptSqlProj>( "", "'$(EfcptSqlProj)'==''");
@@ -459,6 +466,10 @@ public static class BuildTransitivePropsFactory
   public readonly struct EfcptRenaming : IMsBuildPropertyName
   {
     public string Name => "EfcptRenaming";
+  }
+  public readonly struct EfcptRunDuringDesignTimeBuild : IMsBuildPropertyName
+  {
+    public string Name => "EfcptRunDuringDesignTimeBuild";
   }
   public readonly struct EfcptSdkVersionWarningLevel : IMsBuildPropertyName
   {

--- a/src/JD.Efcpt.Build.Definitions/BuildTransitiveTargetsFactory.cs
+++ b/src/JD.Efcpt.Build.Definitions/BuildTransitiveTargetsFactory.cs
@@ -25,7 +25,16 @@ public static class BuildTransitiveTargetsFactory
             {
                 t.PropertyGroup(null, SharedPropertyGroups.ConfigureNullableReferenceTypes);
                 t.PropertyGroup(null, SharedPropertyGroups.ConfigureTaskAssemblyResolution);
-                
+                t.PropertyGroup(null, SharedPropertyGroups.ConfigureDesignTimeBuildGuard);
+
+                // Design-Time Build Guard: diagnostic only. The actual skip happens via the
+                // EfcptEnabled override above (ConfigureDesignTimeBuildGuard).
+                t.Target("_EfcptDesignTimeBuildSkipped", target =>
+                {
+                    target.BeforeTargets("Build", "CoreCompile");
+                    target.Condition("'$(DesignTimeBuild)' == 'true' and '$(EfcptRunDuringDesignTimeBuild)' != 'true'");
+                    target.Message("[Efcpt] Skipping EF Core Power Tools generation pipeline: DesignTimeBuild='$(DesignTimeBuild)'. Set EfcptRunDuringDesignTimeBuild=true to force generation during design-time builds.", "Low");
+                });
                 t.Target("_EfcptDetectSqlProject", target =>
                 {
                     target.BeforeTargets("BeforeBuild", "BeforeRebuild");

--- a/src/JD.Efcpt.Build.Definitions/Shared/SharedPropertyGroups.cs
+++ b/src/JD.Efcpt.Build.Definitions/Shared/SharedPropertyGroups.cs
@@ -40,7 +40,24 @@ public static class SharedPropertyGroups
         group.Property<EfcptConfigUseNullableReferenceTypes>("true", 
             "'$(EfcptConfigUseNullableReferenceTypes)'=='' and ('$(Nullable)'=='enable' or '$(Nullable)'=='Enable')");
         
-        group.Property<EfcptConfigUseNullableReferenceTypes>("false", 
+        group.Property<EfcptConfigUseNullableReferenceTypes>("false",
             "'$(EfcptConfigUseNullableReferenceTypes)'=='' and '$(Nullable)'!=''");
+    }
+
+    /// <summary>
+    /// Forces EfcptEnabled=false for the duration of an IDE design-time build (IntelliSense),
+    /// unless the consuming project opted back in via EfcptRunDuringDesignTimeBuild=true.
+    /// </summary>
+    /// <remarks>
+    /// This must run in the targets file (evaluated after the consuming project's own
+    /// PropertyGroup), not in props (evaluated before it) - otherwise a project-level
+    /// &lt;EfcptRunDuringDesignTimeBuild&gt;true&lt;/EfcptRunDuringDesignTimeBuild&gt; override
+    /// would not be visible yet when this condition is checked, and the pipeline would stay
+    /// disabled even when the user explicitly asked for it to run.
+    /// </remarks>
+    public static void ConfigureDesignTimeBuildGuard(PropsGroupBuilder group)
+    {
+        group.Property<EfcptEnabled>("false",
+            "'$(EfcptEnabled)'=='true' and '$(DesignTimeBuild)'=='true' and '$(EfcptRunDuringDesignTimeBuild)'!='true'");
     }
 }

--- a/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.props
+++ b/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.props
@@ -16,6 +16,12 @@
       To explicitly disable, set:
         <EfcptEnabled>false</EfcptEnabled>-->
     <EfcptEnabled Condition="'$(EfcptEnabled)' == ''">true</EfcptEnabled>
+    <!--Design-Time Build Guard: default for the opt-back-in override. The actual guard that
+      forces EfcptEnabled=false during a design-time build is applied in JD.Efcpt.Build.targets
+      (not here), because this props file is imported very early - before the consuming
+      project's own <PropertyGroup> has had a chance to set EfcptRunDuringDesignTimeBuild. See
+      the targets file for the full rationale and the guard itself.-->
+    <EfcptRunDuringDesignTimeBuild Condition="'$(EfcptRunDuringDesignTimeBuild)' == ''">false</EfcptRunDuringDesignTimeBuild>
     <!--Output-->
     <EfcptOutput Condition="'$(EfcptOutput)' == ''">$(BaseIntermediateOutputPath)efcpt\</EfcptOutput>
     <EfcptGeneratedDir Condition="'$(EfcptGeneratedDir)' == ''">$(EfcptOutput)Generated\</EfcptGeneratedDir>

--- a/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.targets
+++ b/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.targets
@@ -6,6 +6,28 @@
     <EfcptConfigUseNullableReferenceTypes Condition="('$(EfcptConfigUseNullableReferenceTypes)' == '') and (('$(Nullable)' == 'enable') or ('$(Nullable)' == 'Enable'))">true</EfcptConfigUseNullableReferenceTypes>
     <EfcptConfigUseNullableReferenceTypes Condition="('$(EfcptConfigUseNullableReferenceTypes)' == '') and ('$(Nullable)' != '')">false</EfcptConfigUseNullableReferenceTypes>
   </PropertyGroup>
+  <!--Design-Time Build Guard: IDEs (Visual Studio, Rider) run "design-time builds" to power
+    IntelliSense, which set the DesignTimeBuild property to true. Without a guard, a DTB would
+    still walk the entire pipeline (tool restore, SDK checks, efcpt invocation) since every
+    pipeline target is BeforeTargets="CoreCompile" and DTBs evaluate CoreCompile's inputs. This
+    forces EfcptEnabled=false for the duration of a DTB, short-circuiting every EfcptEnabled-gated
+    target in one place instead of scattering the condition across the pipeline.
+
+    This override lives here (in the targets file, evaluated after the consuming project's own
+    <PropertyGroup>) rather than in JD.Efcpt.Build.props, so that a project-level
+    <EfcptRunDuringDesignTimeBuild>true</EfcptRunDuringDesignTimeBuild> override is visible by the
+    time this condition is evaluated. Doing this in props (evaluated before project content) would
+    see the pre-project-body default and permanently disable the pipeline even when the user
+    opted back in.-->
+  <PropertyGroup>
+    <EfcptEnabled Condition="'$(EfcptEnabled)' == 'true' and '$(DesignTimeBuild)' == 'true' and '$(EfcptRunDuringDesignTimeBuild)' != 'true'">false</EfcptEnabled>
+  </PropertyGroup>
+  <!--Design-Time Build Guard: Emits a low-importance diagnostic (visible with -v:diag) explaining
+    why the generation pipeline was skipped. The actual skip happens above via the EfcptEnabled
+    override, so this target intentionally does not gate anything itself.-->
+  <Target Name="_EfcptDesignTimeBuildSkipped" BeforeTargets="Build;CoreCompile" Condition="'$(DesignTimeBuild)' == 'true' and '$(EfcptRunDuringDesignTimeBuild)' != 'true'">
+    <Message Text="[Efcpt] Skipping EF Core Power Tools generation pipeline: DesignTimeBuild='$(DesignTimeBuild)'. Set EfcptRunDuringDesignTimeBuild=true to force generation during design-time builds." Importance="Low" />
+  </Target>
   <!--SQL Project Detection: Detect SQL database projects via SDK attribute or MSBuild properties. Must be in targets file for SDK property availability.-->
   <Target Name="_EfcptDetectSqlProject" BeforeTargets="BeforeBuild;BeforeRebuild">
     <DetectSqlProject DSP="$(DSP)" ProjectPath="$(MSBuildProjectFullPath)" SqlServerVersion="$(SqlServerVersion)">

--- a/tests/JD.Efcpt.Sdk.IntegrationTests/DesignTimeBuildTests.cs
+++ b/tests/JD.Efcpt.Sdk.IntegrationTests/DesignTimeBuildTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Xunit;
+
+namespace JD.Efcpt.Sdk.IntegrationTests;
+
+/// <summary>
+/// Verifies the design-time build guard: the EF Core Power Tools generation pipeline must be
+/// skipped entirely when MSBuild reports DesignTimeBuild=true (as IDEs do for IntelliSense),
+/// unless the user opts back in via EfcptRunDuringDesignTimeBuild=true.
+/// </summary>
+[Collection("Design-Time Build Tests")]
+public class DesignTimeBuildTests : IDisposable
+{
+    private const string SkippedMessage = "[Efcpt] Skipping EF Core Power Tools generation pipeline";
+
+    private readonly SdkPackageTestFixture _fixture;
+    private readonly TestProjectBuilder _builder;
+
+    public DesignTimeBuildTests(SdkPackageTestFixture fixture)
+    {
+        _fixture = fixture;
+        _builder = new TestProjectBuilder(fixture);
+    }
+
+    public void Dispose() => _builder.Dispose();
+
+    [Fact]
+    public async Task DesignTimeBuild_SkipsGenerationPipeline()
+    {
+        // Arrange
+        TestProjectBuilder.CopyDatabaseProject(SdkPackageTestFixture.GetTestFixturesPath());
+        _builder.CreateSdkProject("DtbSkipProject", "net8.0");
+
+        // Act - simulate what Visual Studio/Rider pass for a design-time build
+        var buildResult = await _builder.BuildAsync("-v:d -p:DesignTimeBuild=true");
+
+        // Assert
+        buildResult.Success.Should().BeTrue($"Design-time build should still succeed.\n{buildResult}");
+        buildResult.Output.Should().Contain(SkippedMessage,
+            "the DTB guard should log why the pipeline was skipped");
+        _builder.GetGeneratedFiles().Should().BeEmpty(
+            "no EF Core models should be generated during a design-time build");
+    }
+
+    [Fact]
+    public async Task NonDesignTimeBuild_RunsGenerationPipeline()
+    {
+        // Arrange
+        TestProjectBuilder.CopyDatabaseProject(SdkPackageTestFixture.GetTestFixturesPath());
+        _builder.CreateSdkProject("DtbNormalProject", "net8.0");
+
+        // Act - a normal build (DesignTimeBuild unset/false)
+        var buildResult = await _builder.BuildAsync("-v:d");
+
+        // Assert
+        buildResult.Success.Should().BeTrue($"Build should succeed.\n{buildResult}");
+        buildResult.Output.Should().NotContain(SkippedMessage,
+            "a normal build should not be treated as a design-time build");
+        _builder.GetGeneratedFiles().Should().NotBeEmpty(
+            $"EF Core models should be generated during a normal build.\n{buildResult}");
+    }
+
+    [Fact]
+    public async Task DesignTimeBuild_WithOverride_RunsGenerationPipeline()
+    {
+        // Arrange
+        TestProjectBuilder.CopyDatabaseProject(SdkPackageTestFixture.GetTestFixturesPath());
+        _builder.CreateSdkProject("DtbOverrideProject", "net8.0");
+        _builder.AddProjectProperty("EfcptRunDuringDesignTimeBuild", "true");
+
+        // Act - design-time build, but the user explicitly opted back in
+        var buildResult = await _builder.BuildAsync("-v:d -p:DesignTimeBuild=true");
+
+        // Assert
+        buildResult.Success.Should().BeTrue($"Build should succeed.\n{buildResult}");
+        buildResult.Output.Should().NotContain(SkippedMessage,
+            "the pipeline should not be skipped once the user opts back in");
+        _builder.GetGeneratedFiles().Should().NotBeEmpty(
+            "EF Core models should still be generated when EfcptRunDuringDesignTimeBuild=true");
+    }
+}
+
+[CollectionDefinition("Design-Time Build Tests", DisableParallelization = true)]
+public class DesignTimeBuildTestCollection : ICollectionFixture<SdkPackageTestFixture> { }


### PR DESCRIPTION
## Problem

The entire EF Core model generation pipeline hooks `BeforeTargets="CoreCompile"` unconditionally (`EfcptGenerateModels`, `EfcptAddToCompile`, and the full `DependsOnTargets` chain behind them). Visual Studio and Rider run **design-time builds** (DTBs) to power IntelliSense — these execute CoreCompile's dependency graph too, so every IDE keystroke/file-open could trigger tool restore, SDK checks, `dnx`/SDK probing inside `RunEfcpt`, and even a full efcpt invocation. Until now this was mitigated only by XXH64 fingerprint caching rather than being skipped outright. This was the project's #1 technical risk.

## Fix

A single root-level guard rather than conditions scattered across ~20 targets:

- **`src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.targets`** — a late-evaluated `PropertyGroup` forces `EfcptEnabled=false` when `'$(DesignTimeBuild)' == 'true'` (unless overridden, see below). Since virtually every pipeline target conditions on `'$(EfcptEnabled)' == 'true'`, this one property flip short-circuits the entire pipeline: SQL project detection/generation, tool restore, SDK version check, input resolution, fingerprinting, `RunEfcpt` (including its dnx/SDK probes), and compile-item injection.
- A new `_EfcptDesignTimeBuildSkipped` target emits a `Message Importance="Low"` diagnostic (visible with `-v:diag`/`-v:d`) explaining why the pipeline was skipped.
- **New property `EfcptRunDuringDesignTimeBuild`** (default `false`, declared in `JD.Efcpt.Build.props`): set to `true` to force generation during design-time builds if you really want it.

### Two MSBuild evaluation-order subtleties (found via failing tests, both matter)

1. **No `BuildingProject` check.** The commonly-cited guard pattern `'$(DesignTimeBuild)' != 'true' AND '$(BuildingProject)' == 'true'` is wrong for this package: our props/targets are imported from the NuGet `build/` folder, *before* `Microsoft.Common.CurrentVersion.targets` populates `BuildingProject`. Checking it at import time evaluates empty/not-true for **normal** builds and disabled the pipeline everywhere. `DesignTimeBuild` is a global property set by the IDE before evaluation, so it is reliable.
2. **Guard lives in `.targets`, not `.props`.** The props file is imported before the consuming project's own `<PropertyGroup>`, so a project-level `<EfcptRunDuringDesignTimeBuild>true</EfcptRunDuringDesignTimeBuild>` override wouldn't be visible yet. The targets file evaluates after project content — same pattern the package already uses for `Nullable`-derived defaults.

Both `.props`/`.targets` (generated files, checked in as source of truth per `src/JD.Efcpt.Build/GENERATING.md`) and their C# definitions (`src/JD.Efcpt.Build.Definitions/`) were updated in sync. Note the Definitions project does not compile on current `main` (41 pre-existing errors, e.g. `SharedPropertyGroups.cs(19,13): error CS1739` — it is not in the solution); the C# edits mirror the XML for when that is fixed.

## Tests

New `tests/JD.Efcpt.Sdk.IntegrationTests/DesignTimeBuildTests.cs` (3 tests, following the existing `TestProjectBuilder` real-`dotnet build` harness):
- `DesignTimeBuild_SkipsGenerationPipeline` — `-p:DesignTimeBuild=true` build succeeds, logs the skip message, generates **no** files
- `NonDesignTimeBuild_RunsGenerationPipeline` — normal build generates models, no skip message
- `DesignTimeBuild_WithOverride_RunsGenerationPipeline` — DTB + `EfcptRunDuringDesignTimeBuild=true` still generates

All 3 pass locally. Full local runs: `JD.Efcpt.Build.Tests` 907/925 passed (7 skipped; 11 failures are pre-existing — `EfcptConfigGeneratorTests.FindRepoRoot()` checks `.git` as a *directory*, which fails in git worktrees where `.git` is a file; fails identically on pristine main). `JD.Efcpt.Sdk.IntegrationTests` 81/84 passed locally excluding 5 `FrameworkMsBuildTests` failures that also reproduce identically on pristine main in this environment (locally-packed nupkg missing `tasks/net472`; these are `SkippableFact` without VS). Docker was available; no Testcontainers tests were skipped for that reason.

## Docs

`EfcptRunDuringDesignTimeBuild` documented in `docs/user-guide/configuration.md` (Core Properties) and `docs/user-guide/api-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
