### PR TITLE
fix(build): make SDK probe cache exception-safe (#187 follow-up)

### DIFF
--- a/src/JD.Efcpt.Build.Tasks/Utilities/SdkProbeCache.cs
+++ b/src/JD.Efcpt.Build.Tasks/Utilities/SdkProbeCache.cs
@@ -16,7 +16,9 @@ namespace JD.Efcpt.Build.Tasks.Utilities;
 /// the cost needlessly. This cache ensures a given probe only executes once per distinct
 /// <c>(probeName, dotnetExe, muxer-last-write-time)</c> key for the lifetime of the process
 /// (i.e. a single build session), while still invalidating automatically if the resolved
-/// <c>dotnet</c> path or the muxer binary itself changes (e.g. an SDK upgrade mid-session).
+/// <c>dotnet</c> path or the muxer binary itself changes (e.g. the muxer is replaced in place
+/// mid-session). Note this mtime check does not reliably detect a side-by-side SDK install that
+/// leaves the muxer binary itself untouched.
 /// </para>
 /// <para>
 /// Callers typically pass a bare command name (e.g. <c>"dotnet"</c>) rather than a full path.
@@ -73,7 +75,10 @@ internal static class SdkProbeCache
     /// </param>
     /// <param name="probe">
     /// The factory delegate that performs the actual (expensive) probe. Only invoked when no
-    /// cached determinate result exists yet for the resolved key.
+    /// cached determinate result exists yet for the resolved key. If <paramref name="probe"/>
+    /// throws, the cache itself coerces the failure to <see cref="ProbeOutcome.Transient"/>
+    /// rather than memoizing (and forever rethrowing) the exception via <see cref="Lazy{T}"/> -
+    /// callers do not need to guard against exceptions from <see cref="GetOrProbe"/> themselves.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the probe result (fresh or cached) is
@@ -84,7 +89,9 @@ internal static class SdkProbeCache
     internal static bool GetOrProbe(string probeName, string? dotnetExe, Func<ProbeOutcome> probe)
     {
         var key = BuildKey(probeName, dotnetExe);
-        var lazy = Cache.GetOrAdd(key, _ => new Lazy<ProbeOutcome>(probe, LazyThreadSafetyMode.ExecutionAndPublication));
+        var lazy = Cache.GetOrAdd(key, _ => new Lazy<ProbeOutcome>(
+            () => { try { return probe(); } catch { return ProbeOutcome.Transient; } },
+            LazyThreadSafetyMode.ExecutionAndPublication));
         var outcome = lazy.Value;
 
         if (outcome == ProbeOutcome.Transient)

--- a/tests/JD.Efcpt.Build.Tests/SdkProbeCacheTests.cs
+++ b/tests/JD.Efcpt.Build.Tests/SdkProbeCacheTests.cs
@@ -282,4 +282,32 @@ public sealed partial class SdkProbeCacheTests(ITestOutputHelper output) : TinyB
             .And("the factory was invoked twice - the transient result was not cached", _ => counter == 2)
             .AssertPassed();
     }
+
+    [Scenario("GetOrProbe treats a thrown exception as a transient failure and does not poison the cache")]
+    [Fact]
+    public async Task GetOrProbe_does_not_poison_cache_when_probe_throws()
+    {
+        SdkProbeCache.Clear();
+        var counter = 0;
+        ProbeOutcome Probe()
+        {
+            var invocation = Interlocked.Increment(ref counter);
+            if (invocation == 1)
+                throw new InvalidOperationException("simulated probe failure");
+
+            return ProbeOutcome.Available;
+        }
+
+        await Given("a probe factory that throws on its first call and succeeds on its second", () => "C:\\fake\\dotnet-throws.exe")
+            .When("GetOrProbe is invoked twice with the same key", dotnetExe =>
+            {
+                var first = SdkProbeCache.GetOrProbe("list-sdks", dotnetExe, Probe);
+                var second = SdkProbeCache.GetOrProbe("list-sdks", dotnetExe, Probe);
+                return (First: first, Second: second);
+            })
+            .Then("the first call reports a negative result without throwing or caching it", r => r.First == false)
+            .And("the second call reports the real (successful) outcome", r => r.Second)
+            .And("the factory was invoked twice - the thrown exception was not memoized", _ => counter == 2)
+            .AssertPassed();
+    }
 }


### PR DESCRIPTION
Follow-up hardening to #187 (PR #193), prescribed by two independent adversarial reviews.

## Problem
`SdkProbeCache.GetOrProbe` stored `new Lazy<ProbeOutcome>(probe, ExecutionAndPublication)`. `Lazy<T>` under ExecutionAndPublication caches a thrown exception and rethrows it forever for that key — permanently poisoning the cache if the probe delegate ever throws. It was safe only because every current caller catches internally (fragile caller-discipline, not a library guarantee).

## Fix
Wrap the probe factory so the cache itself coerces any exception to `ProbeOutcome.Transient` (the codebase's existing "don't memoize, retry next time" outcome). No behavior change for current callers; closes the hole for all future ones. Also tightened two XML-doc comments (the mtime stamp does not reliably detect a side-by-side SDK install that leaves the muxer untouched).

## Tests
Added `GetOrProbe_does_not_poison_cache_when_probe_throws`: probe throws on call 1, succeeds on call 2 — asserts no exception propagates, the real outcome is returned on call 2, and the throw was neither rethrown nor memoized. Targeted SdkProbeCache suite: 14/14 pass.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
