### PR TITLE
feat(191): add EfcptForceRegenerate property for IDE-triggered regeneration

### DIFF
--- a/docs/architecture/FINGERPRINTING.md
+++ b/docs/architecture/FINGERPRINTING.md
@@ -215,12 +215,21 @@ using (var hash = new XxHash64())
 ### Location
 
 ```
-$(ProjectDir)/obj/$(Configuration)/$(TargetFramework)/.efcpt/fingerprint.txt
+$(EfcptFingerprintFile)
 ```
+which defaults to:
+```
+$(EfcptOutput)fingerprint.txt
+```
+where `$(EfcptOutput)` defaults to `$(BaseIntermediateOutputPath)efcpt\` - i.e. `obj/efcpt/`,
+**not** a per-`$(Configuration)`/`$(TargetFramework)` path (`BaseIntermediateOutputPath` is the
+shared `obj\` root, unlike `IntermediateOutputPath` which is per-configuration/TFM). See
+`buildTransitive/JD.Efcpt.Build.props` (`EfcptOutput`, `EfcptFingerprintFile`) for the
+authoritative defaults.
 
 **Example:**
 ```
-/MyProject/obj/Debug/net8.0/.efcpt/fingerprint.txt
+/MyProject/obj/efcpt/fingerprint.txt
 ```
 
 ### Content
@@ -283,7 +292,7 @@ ABC123DEF456789
 ```csharp
 public bool ShouldRegenerate()
 {
-    string fingerprintPath = Path.Combine(intermediateOutputPath, ".efcpt", "fingerprint.txt");
+    string fingerprintPath = Path.Combine(baseIntermediateOutputPath, "efcpt", "fingerprint.txt");
 
     // First build or after clean
     if (!File.Exists(fingerprintPath))
@@ -330,7 +339,7 @@ public bool ShouldRegenerate()
    dotnet build
 
    # Check if fingerprint changed
-   cat obj/Debug/net8.0/.efcpt/fingerprint.txt
+   cat obj/efcpt/fingerprint.txt
    ```
 
 3. **Look for:**
@@ -358,14 +367,19 @@ public bool ShouldRegenerate()
 
 ```bash
 # Check current fingerprint
-cat obj/Debug/net8.0/.efcpt/fingerprint.txt
+cat obj/efcpt/fingerprint.txt
 
 # Force regeneration by deleting fingerprint
-rm obj/Debug/net8.0/.efcpt/fingerprint.txt
+rm obj/efcpt/fingerprint.txt
 
 # Rebuild
 dotnet build
 ```
+
+> **Prefer `-p:EfcptForceRegenerate=true` over manually deleting the fingerprint/stamp files.**
+> It's the supported, stable way to force a full regeneration for one build (e.g. from an IDE
+> extension or CLI wrapper) without reaching into `obj/`. See
+> [force-regenerate.md](../user-guide/force-regenerate.md).
 
 **Common Causes:**
 
@@ -385,18 +399,18 @@ dotnet build
 **Diagnosis:**
 
 ```bash
-# Check intermediate output path
-dotnet build /p:IntermediateOutputPath=obj/Debug/net8.0/
+# Check the base intermediate output path
+dotnet build /p:BaseIntermediateOutputPath=obj/
 
-# Verify .efcpt directory creation
-ls -la obj/Debug/net8.0/.efcpt/
+# Verify the efcpt directory creation ($(EfcptOutput), default obj/efcpt/)
+ls -la obj/efcpt/
 ```
 
 **Common Causes:**
 
 | Cause | Solution |
 |-------|----------|
-| Custom clean target deletes .efcpt/ | Exclude from clean |
+| Custom clean target deletes efcpt/ | Exclude from clean |
 | Permissions issue | Check write permissions on obj/ |
 | MSBuild incremental build disabled | Enable incremental builds |
 
@@ -448,15 +462,19 @@ dotnet build -c Debug &
 dotnet build -c Release &
 ```
 
-**Fingerprint Isolation:**
-- Each configuration has separate `obj/` directory
-- Each has independent `fingerprint.txt`
-- No collision or race conditions
+**Fingerprint Isolation - default is NOT isolated per configuration/TFM:**
+- `EfcptOutput` defaults to `$(BaseIntermediateOutputPath)efcpt\` (`obj/efcpt/`), and
+  `BaseIntermediateOutputPath` is the same `obj\` root regardless of `$(Configuration)` or
+  `$(TargetFramework)` - unlike `$(IntermediateOutputPath)`, which *is* per-configuration/TFM.
+- By default, `Debug` and `Release` builds of the same project **share** one
+  `obj/efcpt/fingerprint.txt` / `obj/efcpt/.efcpt.stamp` pair.
+- Building multiple configurations of the same project concurrently can race on that shared state.
+  If you need isolation, set `EfcptOutput` explicitly per configuration/TFM, e.g.
+  `<EfcptOutput>$(IntermediateOutputPath)efcpt\</EfcptOutput>`.
 
-**Location:**
+**Location (default, shared across configurations/TFMs):**
 ```
-obj/Debug/net8.0/.efcpt/fingerprint.txt
-obj/Release/net8.0/.efcpt/fingerprint.txt
+obj/efcpt/fingerprint.txt
 ```
 
 ## Performance Impact
@@ -514,7 +532,7 @@ Speedup: 37x - 300x faster
 **Never:**
 ```bash
 # ❌ Don't do this
-echo "FAKE123" > obj/Debug/net8.0/.efcpt/fingerprint.txt
+echo "FAKE123" > obj/efcpt/fingerprint.txt
 ```
 
 **Reason:**

--- a/docs/user-guide/force-regenerate.md
+++ b/docs/user-guide/force-regenerate.md
@@ -78,9 +78,10 @@ target for one build.
 
 ## What it does *not* do
 
-- It does not disable the fingerprint computation itself - `EfcptComputeFingerprint` still runs
-  and still writes a fresh fingerprint, so the *next* build (without `EfcptForceRegenerate`) goes
-  straight back to normal incremental behavior.
+- It does not disable fingerprint computation - `EfcptComputeFingerprint` still runs; the
+  fingerprint file is rewritten only if the computed value actually changed (when it's unchanged,
+  the existing correct value is left in place, not overwritten). Either way the *next* build
+  (without `EfcptForceRegenerate`) is correctly incremental again.
 - It does not affect `EfcptDetectGeneratedFileChanges`, `EfcptOfflineMode`, or any other cache/gate
   outside the fingerprint+stamp pair.
 - It is scoped to `EfcptGenerateModels`; it does not force-rebuild the referenced `.sqlproj` or

--- a/docs/user-guide/force-regenerate.md
+++ b/docs/user-guide/force-regenerate.md
@@ -1,0 +1,92 @@
+# Forcing Regeneration (`EfcptForceRegenerate`)
+
+By default, `EfcptGenerateModels` only regenerates code when it needs to: when the computed
+schema/config fingerprint changed, or when the stamp file (`EfcptStampFile`) is missing (see
+[Fingerprinting](../architecture/FINGERPRINTING.md)). That incremental gate is what makes repeat
+builds fast, but it also means there was previously no first-class, stable way to say "regenerate
+right now, regardless of the cache" - the only options were manually deleting
+`obj/efcpt/fingerprint.txt` / `obj/efcpt/.efcpt.stamp`, or `dotnet clean`, both of which reach
+into an intermediate-output implementation detail that isn't a supported contract.
+
+`EfcptForceRegenerate` is that first-class contract.
+
+## Usage
+
+```bash
+dotnet build -p:EfcptForceRegenerate=true
+```
+
+or from MSBuild:
+
+```xml
+<PropertyGroup>
+  <EfcptForceRegenerate>true</EfcptForceRegenerate>
+</PropertyGroup>
+```
+
+Default: `false`. When unset or `false`, generation behaves exactly as it does today -
+incremental, fingerprint-gated. Setting `EfcptForceRegenerate=true` bypasses the
+fingerprint/incremental cache **for that one build** and always re-runs `EfcptGenerateModels`,
+even if nothing changed. It is not a persistent setting the pipeline remembers; pass it again on
+the next build if you need another forced regeneration.
+
+## Why this exists
+
+This property is the supported integration point for tooling that needs to trigger regeneration
+programmatically - most notably IDE extensions (Visual Studio, VS Code) and CLI wrappers such as
+`jd-efcpt` - without depending on `obj/`-relative file paths that are an implementation detail and
+could change. "Right-click → Regenerate Models" (or the CLI equivalent) is expected to invoke a
+build with `EfcptForceRegenerate=true` set, rather than deleting cache files by hand.
+
+## How it works
+
+`EfcptGenerateModels` is gated by both a `Condition` and MSBuild `Inputs`/`Outputs` incremental
+evaluation:
+
+```xml
+<Target Name="EfcptGenerateModels"
+        BeforeTargets="CoreCompile"
+        DependsOnTargets="BeforeEfcptGeneration"
+        Inputs="$(_EfcptDacpacPath);$(_EfcptStagedConfig);$(_EfcptStagedRenaming)"
+        Outputs="$(EfcptStampFile)"
+        Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and
+                   ('$(_EfcptFingerprintChanged)' == 'true' or !Exists('$(EfcptStampFile)') or
+                    '$(EfcptForceRegenerate)' == 'true')">
+```
+
+Adding `'$(EfcptForceRegenerate)' == 'true'` to the `Condition` is necessary but not sufficient:
+even with a true `Condition`, MSBuild's `Inputs`/`Outputs` comparison can still decide the target's
+outputs are up to date and skip its tasks. To make forcing genuinely force a re-run, a small
+internal target, `_EfcptForceRegenerateInvalidateStamp`, is hooked in with
+`BeforeTargets="EfcptGenerateModels"` and - only when `EfcptForceRegenerate=true` - deletes the
+stamp file before `EfcptGenerateModels`'s own up-to-date check runs:
+
+```xml
+<Target Name="_EfcptForceRegenerateInvalidateStamp" BeforeTargets="EfcptGenerateModels"
+        Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and
+                   '$(EfcptForceRegenerate)' == 'true'">
+  <Delete Condition="Exists('$(EfcptStampFile)')" Files="$(EfcptStampFile)" />
+</Target>
+```
+
+`BeforeTargets`-hooked targets run after their target's `DependsOnTargets` chain but before the
+target's own `Inputs`/`Outputs` evaluation, so by the time MSBuild checks whether
+`EfcptGenerateModels`'s declared `Outputs` (`$(EfcptStampFile)`) are up to date, the stamp file no
+longer exists - the outputs are missing, so the target is never considered up to date. This is the
+same mechanism MSBuild itself uses for "clean and rebuild" semantics, applied surgically to one
+target for one build.
+
+## What it does *not* do
+
+- It does not disable the fingerprint computation itself - `EfcptComputeFingerprint` still runs
+  and still writes a fresh fingerprint, so the *next* build (without `EfcptForceRegenerate`) goes
+  straight back to normal incremental behavior.
+- It does not affect `EfcptDetectGeneratedFileChanges`, `EfcptOfflineMode`, or any other cache/gate
+  outside the fingerprint+stamp pair.
+- It is scoped to `EfcptGenerateModels`; it does not force-rebuild the referenced `.sqlproj` or
+  re-extract a SQL-project schema.
+
+## See also
+
+- [Fingerprinting](../architecture/FINGERPRINTING.md) - how the fingerprint/stamp incremental gate
+  works day-to-day.

--- a/docs/user-guide/toc.yml
+++ b/docs/user-guide/toc.yml
@@ -24,6 +24,8 @@
   href: split-outputs.md
 - name: Tool Acquisition
   href: tool-acquisition.md
+- name: Forcing Regeneration
+  href: force-regenerate.md
 - name: jd-efcpt CLI
   href: cli.md
 - name: Advanced Topics

--- a/src/JD.Efcpt.Build.Definitions/BuildTransitivePropsFactory.cs
+++ b/src/JD.Efcpt.Build.Definitions/BuildTransitivePropsFactory.cs
@@ -80,6 +80,11 @@ public static class BuildTransitivePropsFactory
                     group.Property<EfcptFingerprintFile>( "$(EfcptOutput)fingerprint.txt", "'$(EfcptFingerprintFile)'==''");
                     group.Property<EfcptStampFile>( "$(EfcptOutput).efcpt.stamp", "'$(EfcptStampFile)'==''");
                     group.Property<EfcptDetectGeneratedFileChanges>( "false", "'$(EfcptDetectGeneratedFileChanges)'==''");
+                    // Extension-facing forced regeneration (#191, prerequisite for VS #182 / VS
+                    // Code #183 integrations): when true, bypasses the fingerprint/incremental
+                    // cache for one build and always re-runs EfcptGenerateModels. Must stay
+                    // "false" here to preserve today's incremental/fingerprint-gated default.
+                    group.Property<EfcptForceRegenerate>( "false", "'$(EfcptForceRegenerate)'==''");
                     group.Property<EfcptLogVerbosity>( "minimal", "'$(EfcptLogVerbosity)'==''");
                     group.Property<EfcptDumpResolvedInputs>( "false", "'$(EfcptDumpResolvedInputs)'==''");
                     group.Property<EfcptAutoDetectWarningLevel>( "Info", "'$(EfcptAutoDetectWarningLevel)'==''");
@@ -522,6 +527,10 @@ public static class BuildTransitivePropsFactory
   public readonly struct EfcptFingerprintFile : IMsBuildPropertyName
   {
     public string Name => "EfcptFingerprintFile";
+  }
+  public readonly struct EfcptForceRegenerate : IMsBuildPropertyName
+  {
+    public string Name => "EfcptForceRegenerate";
   }
   public readonly struct EfcptForceUpdateCheck : IMsBuildPropertyName
   {

--- a/src/JD.Efcpt.Build.Definitions/BuildTransitiveTargetsFactory.cs
+++ b/src/JD.Efcpt.Build.Definitions/BuildTransitiveTargetsFactory.cs
@@ -495,13 +495,34 @@ public static class BuildTransitiveTargetsFactory
                     target.DependsOnTargets("EfcptComputeFingerprint");
                     target.Condition("'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true'");
                 });
+                // Force-regenerate stamp invalidation (#191, prerequisite for VS #182 / VS Code
+                // #183 integrations): EfcptGenerateModels has MSBuild Inputs/Outputs incremental
+                // gating (Outputs="$(EfcptStampFile)") in addition to its Condition. Setting the
+                // Condition to also honor EfcptForceRegenerate is not enough by itself - if the
+                // stamp file is still up to date relative to Inputs, MSBuild would still consider
+                // the target's tasks up to date and skip them. This BeforeTargets hook runs
+                // immediately before EfcptGenerateModels's own Inputs/Outputs check (BeforeTargets
+                // hooks execute after DependsOnTargets but before the target's own up-to-date
+                // evaluation), so deleting the stamp file here makes Outputs missing and forces a
+                // genuine re-run for one build - the cleanest MSBuild-idiomatic way to defeat
+                // incremental gating without touching the Inputs/Outputs lists themselves.
+                t.Target("_EfcptForceRegenerateInvalidateStamp", target =>
+                {
+                    target.BeforeTargets(new EfcptGenerateModelsTarget());
+                    target.Condition("'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and '$(EfcptForceRegenerate)' == 'true'");
+                    target.Message("[Efcpt] EfcptForceRegenerate=true - forcing full model regeneration (bypassing fingerprint/incremental cache) for this build.", "normal");
+                    target.Task("Delete", task =>
+                    {
+                        task.Param("Files", "$(EfcptStampFile)");
+                    }, "Exists('$(EfcptStampFile)')");
+                });
                 t.Target<EfcptGenerateModelsTarget>( target =>
                 {
                     target.BeforeTargets("CoreCompile");
                     target.DependsOnTargets("BeforeEfcptGeneration");
                     target.Inputs("$(_EfcptDacpacPath);$(_EfcptStagedConfig);$(_EfcptStagedRenaming)");
                     target.Outputs("$(EfcptStampFile)");
-                    target.Condition("'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and ('$(_EfcptFingerprintChanged)' == 'true' or !Exists('$(EfcptStampFile)'))");
+                    target.Condition("'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and ('$(_EfcptFingerprintChanged)' == 'true' or !Exists('$(EfcptStampFile)') or '$(EfcptForceRegenerate)' == 'true')");
                     target.Task("MakeDir", task =>
                     {
                         task.Param("Directories", "$(EfcptGeneratedDir)");

--- a/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.props
+++ b/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.props
@@ -40,6 +40,7 @@
     <EfcptFingerprintFile Condition="'$(EfcptFingerprintFile)'==''">$(EfcptOutput)fingerprint.txt</EfcptFingerprintFile>
     <EfcptStampFile Condition="'$(EfcptStampFile)'==''">$(EfcptOutput).efcpt.stamp</EfcptStampFile>
     <EfcptDetectGeneratedFileChanges Condition="'$(EfcptDetectGeneratedFileChanges)'==''">false</EfcptDetectGeneratedFileChanges>
+    <EfcptForceRegenerate Condition="'$(EfcptForceRegenerate)'==''">false</EfcptForceRegenerate>
     <EfcptLogVerbosity Condition="'$(EfcptLogVerbosity)'==''">minimal</EfcptLogVerbosity>
     <EfcptDumpResolvedInputs Condition="'$(EfcptDumpResolvedInputs)'==''">false</EfcptDumpResolvedInputs>
     <EfcptAutoDetectWarningLevel Condition="'$(EfcptAutoDetectWarningLevel)'==''">Info</EfcptAutoDetectWarningLevel>

--- a/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.targets
+++ b/src/JD.Efcpt.Build/buildTransitive/JD.Efcpt.Build.targets
@@ -176,7 +176,11 @@
     </ComputeFingerprint>
   </Target>
   <Target Name="BeforeEfcptGeneration" DependsOnTargets="EfcptComputeFingerprint" Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true'" />
-  <Target Name="EfcptGenerateModels" BeforeTargets="CoreCompile" DependsOnTargets="BeforeEfcptGeneration" Inputs="$(_EfcptDacpacPath);$(_EfcptStagedConfig);$(_EfcptStagedRenaming)" Outputs="$(EfcptStampFile)" Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and ('$(_EfcptFingerprintChanged)' == 'true' or !Exists('$(EfcptStampFile)'))">
+  <Target Name="_EfcptForceRegenerateInvalidateStamp" BeforeTargets="EfcptGenerateModels" Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and '$(EfcptForceRegenerate)' == 'true'">
+    <Message Text="[Efcpt] EfcptForceRegenerate=true - forcing full model regeneration (bypassing fingerprint/incremental cache) for this build." Importance="normal" />
+    <Delete Condition="Exists('$(EfcptStampFile)')" Files="$(EfcptStampFile)" />
+  </Target>
+  <Target Name="EfcptGenerateModels" BeforeTargets="CoreCompile" DependsOnTargets="BeforeEfcptGeneration" Inputs="$(_EfcptDacpacPath);$(_EfcptStagedConfig);$(_EfcptStagedRenaming)" Outputs="$(EfcptStampFile)" Condition="'$(EfcptEnabled)' == 'true' and '$(_EfcptIsSqlProject)' != 'true' and ('$(_EfcptFingerprintChanged)' == 'true' or !Exists('$(EfcptStampFile)') or '$(EfcptForceRegenerate)' == 'true')">
     <MakeDir Directories="$(EfcptGeneratedDir)" />
     <RunEfcpt AutoAcquireTool="$(EfcptAutoAcquireTool)" ConfigPath="$(_EfcptStagedConfig)" ConnectionString="$(_EfcptResolvedConnectionString)" DacpacPath="$(_EfcptDacpacPath)" DotNetExe="$(EfcptDotNetExe)" LogVerbosity="$(EfcptLogVerbosity)" OfflineMode="$(EfcptOfflineMode)" OutputDir="$(EfcptGeneratedDir)" ProjectPath="$(MSBuildProjectFullPath)" Provider="$(EfcptProvider)" RenamingPath="$(_EfcptStagedRenaming)" TargetFramework="$(TargetFramework)" TemplateDir="$(_EfcptStagedTemplateDir)" ToolCommand="$(EfcptToolCommand)" ToolMode="$(EfcptToolMode)" ToolPackageId="$(EfcptToolPackageId)" ToolPath="$(EfcptToolPath)" ToolRestore="$(EfcptToolRestore)" ToolVersion="$(EfcptToolVersion)" UseConnectionStringMode="$(_EfcptUseConnectionString)" WorkingDirectory="$(EfcptOutput)" />
     <RenameGeneratedFiles GeneratedDir="$(EfcptGeneratedDir)" LogVerbosity="$(EfcptLogVerbosity)" />

--- a/tests/JD.Efcpt.Build.Tests/ForceRegenerateOrderingTests.cs
+++ b/tests/JD.Efcpt.Build.Tests/ForceRegenerateOrderingTests.cs
@@ -1,0 +1,200 @@
+using JD.Efcpt.Build.Tests.Infrastructure;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Task = System.Threading.Tasks.Task;
+
+namespace JD.Efcpt.Build.Tests;
+
+/// <summary>
+/// End-to-end proof of the crux claim behind #191 (and therefore the VS #182 / VS Code #183
+/// integrations): a target hooked with <c>BeforeTargets="Gen"</c> runs BEFORE <c>Gen</c>'s own
+/// MSBuild <c>Inputs</c>/<c>Outputs</c> up-to-date evaluation, so deleting <c>Gen</c>'s declared
+/// <c>Outputs</c> from that hook genuinely forces <c>Gen</c> to RE-RUN even when it would otherwise
+/// be skipped as up-to-date.
+///
+/// The direct-invocation <see cref="ForceRegenerateTests"/> only prove the invalidation target's
+/// Delete/Condition in isolation - they can't prove the ORDERING relative to the incremental gate.
+/// This test reproduces exactly that pattern (Inputs/Outputs incremental target + a BeforeTargets
+/// stamp-deleting hook gated on a Force property) in a minimal, self-contained synthetic MSBuild
+/// project and drives it with real `dotnet msbuild` invocations - no efcpt tool or database
+/// required. The three-build flow deliberately includes an unforced middle build whose SKIP must be
+/// observed; if that skip does not happen, the whole test is meaningless, so it is asserted
+/// explicitly (run count must NOT increment on the unforced rebuild).
+/// </summary>
+[Feature("Force-regenerate ordering: BeforeTargets stamp-deletion defeats MSBuild Inputs/Outputs incremental gating")]
+[Collection(nameof(AssemblySetup))]
+public sealed partial class ForceRegenerateOrderingTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private sealed record OrderingContext(
+        TestFolder Folder,
+        string ProjectDir,
+        string ProjectPath,
+        string StampFile,
+        string RunCountFile) : IDisposable
+    {
+        public void Dispose() => Folder.Dispose();
+    }
+
+    private sealed record OrderingResult(
+        OrderingContext Context,
+        int RunCountAfterFirst,
+        int RunCountAfterSecondNoForce,
+        int RunCountAfterThirdForce,
+        string StampAfterSecond,
+        string StampAfterThird,
+        string CombinedOutput,
+        bool AllBuildsSucceeded);
+
+    // Minimal synthetic project mirroring the real EfcptGenerateModels + _EfcptForceRegenerateInvalidateStamp
+    // shape: an Inputs/Outputs-gated target plus a BeforeTargets hook that deletes the output stamp
+    // only when Force=true. No SDK, no tasks assembly - pure inbox MSBuild so it runs anywhere.
+    private const string SyntheticProject = """
+        <Project>
+          <PropertyGroup>
+            <InFile Condition="'$(InFile)'==''">$(MSBuildProjectDirectory)/input.txt</InFile>
+            <StampFile Condition="'$(StampFile)'==''">$(MSBuildProjectDirectory)/stamp.txt</StampFile>
+            <RunCountFile Condition="'$(RunCountFile)'==''">$(MSBuildProjectDirectory)/runcount.txt</RunCountFile>
+            <Force Condition="'$(Force)'==''">false</Force>
+          </PropertyGroup>
+
+          <!-- Mirrors _EfcptForceRegenerateInvalidateStamp: runs before Gen's own up-to-date check,
+               deletes Gen's Outputs so the incremental gate cannot skip it. Only when forcing. -->
+          <Target Name="_Invalidate" BeforeTargets="Gen" Condition="'$(Force)' == 'true'">
+            <Delete Condition="Exists('$(StampFile)')" Files="$(StampFile)" />
+          </Target>
+
+          <!-- Mirrors EfcptGenerateModels: Inputs/Outputs-gated. Each real run appends a marker line
+               (so we can count runs) and rewrites the stamp with a fresh value. -->
+          <Target Name="Gen" Inputs="$(InFile)" Outputs="$(StampFile)">
+            <WriteLinesToFile File="$(RunCountFile)" Lines="ran" Overwrite="false" />
+            <WriteLinesToFile File="$(StampFile)" Lines="$([System.DateTime]::UtcNow.Ticks)" Overwrite="true" />
+          </Target>
+        </Project>
+        """;
+
+    private static OrderingContext SetupSyntheticProject()
+    {
+        var folder = new TestFolder();
+        var projectDir = folder.CreateDir("SyntheticOrdering");
+
+        var projectPath = Path.Combine(projectDir, "ordering.proj");
+        File.WriteAllText(projectPath, SyntheticProject);
+
+        // The single Input must exist and be OLDER than the Output stamp for MSBuild to ever
+        // consider Gen up to date. Backdate it so the first Gen run - which writes the stamp "now" -
+        // reliably produces stamp-newer-than-input, independent of filesystem timestamp resolution.
+        var inFile = Path.Combine(projectDir, "input.txt");
+        File.WriteAllText(inFile, "schema-input");
+        File.SetLastWriteTimeUtc(inFile, DateTime.UtcNow.AddHours(-1));
+
+        var stampFile = Path.Combine(projectDir, "stamp.txt");
+        var runCountFile = Path.Combine(projectDir, "runcount.txt");
+
+        return new OrderingContext(folder, projectDir, projectPath, stampFile, runCountFile);
+    }
+
+    private static (int ExitCode, string Output) RunGen(OrderingContext context, bool force)
+    {
+        var arguments = $"msbuild \"{context.ProjectPath}\" -t:Gen -v:normal"
+            + (force ? " -p:Force=true" : string.Empty);
+
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = TestPaths.DotNetExe,
+            Arguments = arguments,
+            WorkingDirectory = context.ProjectDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(120000);
+
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    private static int RunCount(OrderingContext context)
+        => File.Exists(context.RunCountFile)
+            ? File.ReadAllLines(context.RunCountFile).Count(l => !string.IsNullOrWhiteSpace(l))
+            : 0;
+
+    private static string StampContent(OrderingContext context)
+        => File.Exists(context.StampFile) ? File.ReadAllText(context.StampFile).Trim() : "";
+
+    private static OrderingResult RunThreeBuildFlow(OrderingContext context)
+    {
+        var allSucceeded = true;
+
+        // (a) First build - Gen must run (no stamp yet), creating the stamp and marker #1.
+        var (exit1, out1) = RunGen(context, force: false);
+        allSucceeded &= exit1 == 0;
+        var runCountAfterFirst = RunCount(context);
+
+        // (b) Second build, unforced, inputs unchanged - Gen MUST be skipped as up-to-date.
+        //     This is the load-bearing observation: if it is NOT skipped, the test is tautological.
+        var (exit2, out2) = RunGen(context, force: false);
+        allSucceeded &= exit2 == 0;
+        var runCountAfterSecond = RunCount(context);
+        var stampAfterSecond = StampContent(context);
+
+        // (c) Third build with Force=true, inputs STILL unchanged - the BeforeTargets hook deletes
+        //     the stamp before Gen's up-to-date check, so Gen must re-run despite being "up to date".
+        var (exit3, out3) = RunGen(context, force: true);
+        allSucceeded &= exit3 == 0;
+        var runCountAfterThird = RunCount(context);
+        var stampAfterThird = StampContent(context);
+
+        return new OrderingResult(
+            context,
+            runCountAfterFirst,
+            runCountAfterSecond,
+            runCountAfterThird,
+            stampAfterSecond,
+            stampAfterThird,
+            string.Join("\n----\n", out1, out2, out3),
+            allSucceeded);
+    }
+
+    [Scenario("Force=true re-runs an Inputs/Outputs-gated target that an unforced rebuild skips as up-to-date")]
+    [Fact]
+    public Task Force_defeats_inputs_outputs_incremental_gate_via_before_targets_ordering()
+        => Given("a synthetic Inputs/Outputs-gated project with a Force-gated BeforeTargets stamp deleter", SetupSyntheticProject)
+            .When("building three times: initial, unforced rebuild, then forced rebuild (inputs never change)", RunThreeBuildFlow)
+            .Then("all three builds succeed", r =>
+            {
+                if (!r.AllBuildsSucceeded)
+                    throw new InvalidOperationException($"One or more msbuild invocations failed. Output:\n{r.CombinedOutput}");
+                return true;
+            })
+            .And("(a) the first build ran Gen (run count = 1)", r => r.RunCountAfterFirst == 1)
+            .And("(b) the unforced rebuild SKIPPED Gen as up-to-date (run count still 1)", r => r.RunCountAfterSecondNoForce == 1)
+            .And("(c) the forced rebuild RE-RAN Gen despite unchanged inputs (run count = 2)", r => r.RunCountAfterThirdForce == 2)
+            .And("(c) the forced rebuild rewrote the stamp with a fresh value", r =>
+                r.StampAfterThird.Length > 0 && r.StampAfterThird != r.StampAfterSecond)
+            .Finally(r => r.Context.Dispose())
+            .AssertPassed();
+
+    [Scenario("Sanity: without ever forcing, an unchanged rebuild never re-runs the gated target")]
+    [Fact]
+    public Task Unforced_rebuilds_never_rerun_the_gated_target()
+        => Given("a synthetic Inputs/Outputs-gated project", SetupSyntheticProject)
+            .When("building twice, unforced, with unchanged inputs", ctx =>
+            {
+                var (exit1, out1) = RunGen(ctx, force: false);
+                var countAfterFirst = RunCount(ctx);
+                var (exit2, out2) = RunGen(ctx, force: false);
+                var countAfterSecond = RunCount(ctx);
+                return (ctx, exit1, exit2, countAfterFirst, countAfterSecond, output: out1 + "\n----\n" + out2);
+            })
+            .Then("both builds succeed", r => r.exit1 == 0 && r.exit2 == 0)
+            .And("the first build ran the target once", r => r.countAfterFirst == 1)
+            .And("the second build was skipped (up-to-date), proving the incremental gate is real", r => r.countAfterSecond == 1)
+            .Finally(r => r.ctx.Dispose())
+            .AssertPassed();
+}

--- a/tests/JD.Efcpt.Build.Tests/ForceRegenerateTests.cs
+++ b/tests/JD.Efcpt.Build.Tests/ForceRegenerateTests.cs
@@ -1,0 +1,135 @@
+using JD.Efcpt.Build.Tests.Infrastructure;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Task = System.Threading.Tasks.Task;
+
+namespace JD.Efcpt.Build.Tests;
+
+/// <summary>
+/// Proves the EfcptForceRegenerate mechanism (#191): setting EfcptForceRegenerate=true must
+/// genuinely defeat EfcptGenerateModels's MSBuild Inputs/Outputs incremental gate, not just its
+/// Condition. We can't drive the full generation pipeline here (no real efcpt tool / database in
+/// CI), so these tests target the internal _EfcptForceRegenerateInvalidateStamp target directly -
+/// it has no DependsOnTargets, so it can be invoked standalone via `-t:` - and assert on the one
+/// observable side effect that actually defeats the incremental gate: deletion of EfcptStampFile
+/// (EfcptGenerateModels's declared Outputs).
+/// </summary>
+[Feature("EfcptForceRegenerate: force a full model regeneration, bypassing the fingerprint/incremental cache")]
+[Collection(nameof(AssemblySetup))]
+public sealed partial class ForceRegenerateTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private sealed record ForceRegenContext(
+        TestFolder Folder,
+        string AppDir,
+        string StampFile) : IDisposable
+    {
+        public void Dispose() => Folder.Dispose();
+    }
+
+    private sealed record MsBuildResult(
+        ForceRegenContext Context,
+        int ExitCode,
+        string Output,
+        bool StampFileExistedBefore,
+        bool StampFileExistsAfter);
+
+    private static ForceRegenContext SetupProjectWithExistingStamp()
+    {
+        var folder = new TestFolder();
+        var appDir = folder.CreateDir("TestApp");
+
+        var efcptBuildRoot = Path.Combine(TestPaths.RepoRoot, "src", "JD.Efcpt.Build");
+
+        var csproj = $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+
+              <Import Project="{efcptBuildRoot}/JD.Efcpt.Build.props" />
+
+              <PropertyGroup>
+                <EfcptEnabled>true</EfcptEnabled>
+              </PropertyGroup>
+
+              <Import Project="{efcptBuildRoot}/JD.Efcpt.Build.targets" />
+            </Project>
+            """;
+
+        File.WriteAllText(Path.Combine(appDir, "TestApp.csproj"), csproj);
+
+        // Simulate a previous successful generation: stamp file already up to date.
+        var efcptOutputDir = Path.Combine(appDir, "obj", "efcpt");
+        Directory.CreateDirectory(efcptOutputDir);
+        var stampFile = Path.Combine(efcptOutputDir, ".efcpt.stamp");
+        File.WriteAllText(stampFile, "previous-fingerprint-hash");
+
+        return new ForceRegenContext(folder, appDir, stampFile);
+    }
+
+    private static MsBuildResult RunInvalidationTarget(ForceRegenContext context, bool forceRegenerate)
+    {
+        var stampExistedBefore = File.Exists(context.StampFile);
+
+        var arguments = "msbuild -t:_EfcptForceRegenerateInvalidateStamp -v:normal"
+            + (forceRegenerate ? " -p:EfcptForceRegenerate=true" : string.Empty);
+
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = TestPaths.DotNetExe,
+            Arguments = arguments,
+            WorkingDirectory = context.AppDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(60000);
+
+        var output = stdout + stderr;
+        var stampExistsAfter = File.Exists(context.StampFile);
+
+        return new MsBuildResult(context, process.ExitCode, output, stampExistedBefore, stampExistsAfter);
+    }
+
+    [Scenario("EfcptForceRegenerate=true invalidates the stamp file, defeating the Inputs/Outputs incremental gate")]
+    [Fact]
+    public Task ForceRegenerate_true_deletes_existing_stamp_file()
+        => Given("a project with an up-to-date efcpt stamp file", SetupProjectWithExistingStamp)
+            .Then("the stamp file exists before the build", ctx => File.Exists(ctx.StampFile))
+            .When("running the invalidation target with EfcptForceRegenerate=true", ctx => RunInvalidationTarget(ctx, forceRegenerate: true))
+            .Then("the target succeeds", r =>
+            {
+                if (r.ExitCode != 0)
+                    throw new InvalidOperationException($"msbuild failed with exit code {r.ExitCode}. Output: {r.Output}");
+                return true;
+            })
+            .And("the stamp file existed beforehand", r => r.StampFileExistedBefore)
+            .And("the stamp file (EfcptGenerateModels' Outputs) is deleted", r => !r.StampFileExistsAfter)
+            .Finally(r => r.Context.Dispose())
+            .AssertPassed();
+
+    [Scenario("EfcptForceRegenerate unset (default false) leaves the stamp file untouched")]
+    [Fact]
+    public Task ForceRegenerate_default_false_preserves_existing_stamp_file()
+        => Given("a project with an up-to-date efcpt stamp file", SetupProjectWithExistingStamp)
+            .Then("the stamp file exists before the build", ctx => File.Exists(ctx.StampFile))
+            .When("running the invalidation target without EfcptForceRegenerate set", ctx => RunInvalidationTarget(ctx, forceRegenerate: false))
+            .Then("the target succeeds (Condition is false, target is a no-op)", r =>
+            {
+                if (r.ExitCode != 0)
+                    throw new InvalidOperationException($"msbuild failed with exit code {r.ExitCode}. Output: {r.Output}");
+                return true;
+            })
+            .And("the stamp file existed beforehand", r => r.StampFileExistedBefore)
+            .And("the stamp file is left untouched - default behavior is unchanged", r => r.StampFileExistsAfter)
+            .Finally(r => r.Context.Dispose())
+            .AssertPassed();
+}

--- a/tests/JD.Efcpt.Build.Tests/SqlProjectTargetGenerationTests.cs
+++ b/tests/JD.Efcpt.Build.Tests/SqlProjectTargetGenerationTests.cs
@@ -127,5 +127,86 @@ public sealed partial class SqlProjectTargetGenerationTests(ITestOutputHelper ou
         
         _output.WriteLine($"✓ Found {sqlTargetLines.Count} condition statements");
     }
+
+    [Fact]
+    public void EfcptForceRegenerate_property_defaults_to_false_in_generated_props()
+    {
+        // Arrange
+        var testAssemblyPath = typeof(SqlProjectTargetGenerationTests).Assembly.Location;
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testAssemblyPath)!, "..", "..", "..", "..", ".."));
+        var propsPath = Path.Combine(repoRoot, "src", "JD.Efcpt.Build", "buildTransitive", "JD.Efcpt.Build.props");
+
+        // Act
+        Assert.True(File.Exists(propsPath), $"Props file not found at: {propsPath}");
+        var propsContent = File.ReadAllText(propsPath);
+
+        // Assert - the extension-facing force-regenerate property exists and defaults to false,
+        // preserving today's incremental/fingerprint-gated generation when unset (#191).
+        Assert.Contains(
+            "<EfcptForceRegenerate Condition=\"'$(EfcptForceRegenerate)'==''\">false</EfcptForceRegenerate>",
+            propsContent);
+
+        _output.WriteLine("✓ EfcptForceRegenerate defaults to false in generated props");
+    }
+
+    [Fact]
+    public void EfcptGenerateModels_condition_honors_EfcptForceRegenerate()
+    {
+        // Arrange
+        var testAssemblyPath = typeof(SqlProjectTargetGenerationTests).Assembly.Location;
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testAssemblyPath)!, "..", "..", "..", "..", ".."));
+        var targetsPath = Path.Combine(repoRoot, "src", "JD.Efcpt.Build", "buildTransitive", "JD.Efcpt.Build.targets");
+
+        // Act
+        var targetsContent = File.ReadAllText(targetsPath);
+
+        // Assert - EfcptGenerateModels's Condition now also runs generation when
+        // EfcptForceRegenerate=true, in addition to the pre-existing fingerprint-changed /
+        // stamp-missing gates (#191).
+        var generateModelsLine = targetsContent.Split('\n')
+            .First(l => l.Contains("<Target Name=\"EfcptGenerateModels\""));
+        Assert.Contains("'$(_EfcptFingerprintChanged)' == 'true'", generateModelsLine);
+        Assert.Contains("!Exists('$(EfcptStampFile)')", generateModelsLine);
+        Assert.Contains("'$(EfcptForceRegenerate)' == 'true'", generateModelsLine);
+
+        _output.WriteLine("✓ EfcptGenerateModels Condition honors EfcptForceRegenerate");
+    }
+
+    [Fact]
+    public void ForceRegenerate_stamp_invalidation_target_precedes_EfcptGenerateModels()
+    {
+        // Arrange
+        var testAssemblyPath = typeof(SqlProjectTargetGenerationTests).Assembly.Location;
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(testAssemblyPath)!, "..", "..", "..", "..", ".."));
+        var targetsPath = Path.Combine(repoRoot, "src", "JD.Efcpt.Build", "buildTransitive", "JD.Efcpt.Build.targets");
+
+        // Act
+        var targetsContent = File.ReadAllText(targetsPath);
+
+        // Assert - the stamp-invalidation target exists, is hooked in immediately before
+        // EfcptGenerateModels (so it runs before that target's Inputs/Outputs up-to-date check),
+        // is gated on EfcptForceRegenerate=true, and deletes the stamp file so the Outputs of
+        // EfcptGenerateModels are genuinely missing (defeating the incremental gate) rather than
+        // relying solely on the Condition change above (#191).
+        Assert.Contains(
+            "<Target Name=\"_EfcptForceRegenerateInvalidateStamp\" BeforeTargets=\"EfcptGenerateModels\"",
+            targetsContent);
+
+        var invalidationTargetLine = targetsContent.Split('\n')
+            .First(l => l.Contains("<Target Name=\"_EfcptForceRegenerateInvalidateStamp\""));
+        Assert.Contains("'$(EfcptForceRegenerate)' == 'true'", invalidationTargetLine);
+
+        Assert.Contains("<Delete Condition=\"Exists('$(EfcptStampFile)')\" Files=\"$(EfcptStampFile)\" />", targetsContent);
+
+        // And the invalidation target must appear before EfcptGenerateModels in document order,
+        // since BeforeTargets ordering relative to sibling BeforeTargets hooks can depend on
+        // declaration order for readability/debuggability even though MSBuild itself doesn't
+        // require it.
+        var invalidationIndex = targetsContent.IndexOf("<Target Name=\"_EfcptForceRegenerateInvalidateStamp\"", StringComparison.Ordinal);
+        var generateModelsIndex = targetsContent.IndexOf("<Target Name=\"EfcptGenerateModels\"", StringComparison.Ordinal);
+        Assert.True(invalidationIndex >= 0 && generateModelsIndex >= 0 && invalidationIndex < generateModelsIndex);
+
+        _output.WriteLine("✓ _EfcptForceRegenerateInvalidateStamp is correctly wired before EfcptGenerateModels");
+    }
 }
 


### PR DESCRIPTION
## Summary

Prerequisite ("PR-0") for the VS (#182) and VS Code (#183) extensions: adds a first-class `EfcptForceRegenerate` MSBuild property (default `false`) so IDE/CLI integrations can trigger a full model regeneration through a stable public contract instead of poking `obj/`-relative fingerprint/stamp files directly.

- **New property**: `EfcptForceRegenerate` (default `false`) added to `BuildTransitivePropsFactory.cs` → generated `JD.Efcpt.Build.props`.
- **Condition extended**: `EfcptGenerateModels`'s `Condition` now also runs when `EfcptForceRegenerate=true`, in addition to the existing fingerprint-changed / stamp-missing checks.
- **Defeating the Inputs/Outputs incremental gate**: the `Condition` change alone isn't sufficient — `EfcptGenerateModels` also has `Inputs`/`Outputs` (`Outputs="$(EfcptStampFile)"`) incremental gating, which can still consider the target up to date and skip its tasks even when the `Condition` is true. A new internal target, `_EfcptForceRegenerateInvalidateStamp`, is hooked in with `BeforeTargets="EfcptGenerateModels"` and — only when `EfcptForceRegenerate=true` — deletes the stamp file. `BeforeTargets`-hooked targets run after `DependsOnTargets` but before the target's own up-to-date evaluation, so by the time MSBuild checks `EfcptGenerateModels`'s `Outputs`, the stamp file is genuinely missing and the target cannot be skipped. This is the cleanest MSBuild-idiomatic way to force a rebuild without touching the `Inputs`/`Outputs` declarations themselves.
- **Regenerated** `buildTransitive/JD.Efcpt.Build.{props,targets}` via `JDMSBuildFluentGenerate` and committed the output.
- **Tests**: targets-content assertions in `SqlProjectTargetGenerationTests` (property default, extended condition, invalidation-target wiring) plus an executable mechanism test in `ForceRegenerateTests` that runs `dotnet msbuild -t:_EfcptForceRegenerateInvalidateStamp` directly and proves the stamp file is deleted only when `EfcptForceRegenerate=true` (default behavior is untouched otherwise).
- **Docs fix**: `FINGERPRINTING.md` documented the fingerprint path as `obj/Debug/net8.0/.efcpt/fingerprint.txt`, which contradicts the real props default — `EfcptFingerprintFile = $(EfcptOutput)fingerprint.txt`, and `EfcptOutput` defaults to `$(BaseIntermediateOutputPath)efcpt\` (`obj/efcpt/`), **not** per-configuration/TFM (`BaseIntermediateOutputPath` ≠ `IntermediateOutputPath`). Corrected throughout, including a previously-wrong "parallel builds have isolated fingerprints" claim — by default they actually share the same file.
- **New doc**: `docs/user-guide/force-regenerate.md` documents the extension-facing contract (`EfcptForceRegenerate=true` bypasses the fingerprint/incremental cache for one build), with a `toc.yml` entry.

Backward compatible: default behavior with `EfcptForceRegenerate` unset is identical to today's incremental/fingerprint-gated generation (verified via tests + full solution build).

## Test plan

- [x] `dotnet build JD.Efcpt.Build.sln -c Debug` — 0 errors (`TreatWarningsAsErrors=true`)
- [x] `buildTransitive/*.{props,targets}` regenerated and committed; `git status` clean after build
- [x] `dotnet test tests/JD.Efcpt.Build.Tests --filter "FullyQualifiedName~Target |FullyQualifiedName~Generation|FullyQualifiedName~Fingerprint|FullyQualifiedName~Regenerat"` → 107 passed, 2 skipped (pre-existing, require live Snowflake), 0 failed
- [x] New `ForceRegenerateTests` (2) + new `SqlProjectTargetGenerationTests` facts (3) all pass in isolation

Not merging — needs two adversarial reviews first, per the coordinating task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)