### PR TITLE
chore(191): lock v1.0 public API surface (PublicApiAnalyzers)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.7.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="MySqlConnector" Version="2.5.0" />

--- a/build/PublicApi.props
+++ b/build/PublicApi.props
@@ -1,0 +1,40 @@
+<Project>
+  <!--
+    Opt-in shared props for Microsoft.CodeAnalysis.PublicApiAnalyzers (issue #191:
+    PUBLIC-API-STABILITY). Import this explicitly from a project's .csproj - do NOT
+    import it via Directory.Build.props - so only the reusable, externally-consumable
+    library projects pick up the analyzer, not every project in the solution.
+
+    Multi-targeted projects (net472;net8.0;net9.0;net10.0) would otherwise need a
+    separate PublicAPI.Shipped.txt/.Unshipped.txt pair PER TargetFramework, because
+    net472 carries TFM-conditional polyfilled types and looser nullable annotations
+    that diverge from net8.0+, which would produce spurious per-TFM RS0016/RS0017
+    mismatches. To avoid that churn, the analyzer + AdditionalFiles are scoped to a
+    SINGLE canonical TFM via $(PublicApiAnalyzerTfm) - net10.0, the newest/most
+    complete TFM - which locks the real cross-consumer surface once.
+
+    Usage in an importing .csproj (multi-targeted project):
+      <PropertyGroup>
+        <PublicApiAnalyzerTfm>net10.0</PublicApiAnalyzerTfm>
+      </PropertyGroup>
+      <Import Project="..\..\build\PublicApi.props" />
+
+    Usage for a single-TFM project (e.g. netstandard2.0-only JD.Efcpt.Ide.Core, or
+    the net8.0-only JD.Efcpt.Cli): leave $(PublicApiAnalyzerTfm) unset. The analyzer
+    then applies unconditionally to that project's one TFM.
+  -->
+  <PropertyGroup>
+    <_PublicApiAnalyzerEnabled Condition="'$(PublicApiAnalyzerTfm)' == ''">true</_PublicApiAnalyzerEnabled>
+    <_PublicApiAnalyzerEnabled Condition="'$(PublicApiAnalyzerTfm)' != '' And '$(TargetFramework)' == '$(PublicApiAnalyzerTfm)'">true</_PublicApiAnalyzerEnabled>
+    <_PublicApiAnalyzerEnabled Condition="'$(_PublicApiAnalyzerEnabled)' == ''">false</_PublicApiAnalyzerEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_PublicApiAnalyzerEnabled)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime;build;native;contentfiles;analyzers</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+</Project>

--- a/ide/vs/JD.Efcpt.Ide.Core/JD.Efcpt.Ide.Core.csproj
+++ b/ide/vs/JD.Efcpt.Ide.Core/JD.Efcpt.Ide.Core.csproj
@@ -15,6 +15,13 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <!--
+    PublicApiAnalyzers (#191: PUBLIC-API-STABILITY) locks this assembly's public surface.
+    Single-TFM project (netstandard2.0), so build/PublicApi.props applies unconditionally -
+    no PublicApiAnalyzerTfm needed.
+  -->
+  <Import Project="..\..\..\build\PublicApi.props" />
+
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/ide/vs/JD.Efcpt.Ide.Core/PublicAPI.Shipped.txt
+++ b/ide/vs/JD.Efcpt.Ide.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,138 @@
+#nullable enable
+JD.Efcpt.Ide.Core.BuildProfile
+JD.Efcpt.Ide.Core.BuildProfile.Artifacts.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Ide.Core.BuildProfileArtifact!>!
+JD.Efcpt.Ide.Core.BuildProfile.Artifacts.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.BuildProfile() -> void
+JD.Efcpt.Ide.Core.BuildProfile.Diagnostics.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Ide.Core.BuildProfileDiagnostic!>!
+JD.Efcpt.Ide.Core.BuildProfile.Diagnostics.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.Duration.get -> System.TimeSpan?
+JD.Efcpt.Ide.Core.BuildProfile.Duration.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.EndTime.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfile.EndTime.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.ModelCount.get -> int
+JD.Efcpt.Ide.Core.BuildProfile.ModelCount.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.ProjectName.get -> string?
+JD.Efcpt.Ide.Core.BuildProfile.ProjectName.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.RunId.get -> string?
+JD.Efcpt.Ide.Core.BuildProfile.RunId.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.SchemaSupported.get -> bool
+JD.Efcpt.Ide.Core.BuildProfile.SchemaSupported.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.SchemaVersion.get -> string!
+JD.Efcpt.Ide.Core.BuildProfile.SchemaVersion.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.StartTime.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfile.StartTime.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.Status.get -> string!
+JD.Efcpt.Ide.Core.BuildProfile.Status.set -> void
+JD.Efcpt.Ide.Core.BuildProfile.StatusValue.get -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfile.StatusValue.set -> void
+JD.Efcpt.Ide.Core.BuildProfileArtifact
+JD.Efcpt.Ide.Core.BuildProfileArtifact.BuildProfileArtifact() -> void
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Path.get -> string!
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Path.set -> void
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Size.get -> long?
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Size.set -> void
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Type.get -> string!
+JD.Efcpt.Ide.Core.BuildProfileArtifact.Type.set -> void
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.BuildProfileDiagnostic() -> void
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Code.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Code.set -> void
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Message.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Message.set -> void
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Severity.get -> string!
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Severity.set -> void
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Timestamp.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfileDiagnostic.Timestamp.set -> void
+JD.Efcpt.Ide.Core.BuildProfileParseException
+JD.Efcpt.Ide.Core.BuildProfileParseException.BuildProfileParseException(string! message) -> void
+JD.Efcpt.Ide.Core.BuildProfileParseException.BuildProfileParseException(string! message, System.Exception! innerException) -> void
+JD.Efcpt.Ide.Core.BuildProfileReader
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Artifacts.get -> System.Collections.Generic.List<JD.Efcpt.Ide.Core.BuildProfileArtifact!>?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Artifacts.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Diagnostics.get -> System.Collections.Generic.List<JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic!>?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Diagnostics.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Duration.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Duration.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.EndTime.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.EndTime.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Project.get -> JD.Efcpt.Ide.Core.BuildProfileReader.RawProject?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Project.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.RawBuildProfile() -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.RunId.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.RunId.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.SchemaVersion.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.SchemaVersion.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.StartTime.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.StartTime.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Status.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawBuildProfile.Status.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Code.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Code.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Level.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Level.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Message.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Message.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.RawDiagnostic() -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Timestamp.get -> System.DateTimeOffset?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic.Timestamp.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawProject
+JD.Efcpt.Ide.Core.BuildProfileReader.RawProject.Name.get -> string?
+JD.Efcpt.Ide.Core.BuildProfileReader.RawProject.Name.set -> void
+JD.Efcpt.Ide.Core.BuildProfileReader.RawProject.RawProject() -> void
+JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfileStatus.Canceled = 4 -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfileStatus.Failed = 2 -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfileStatus.Skipped = 3 -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfileStatus.Success = 1 -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildProfileStatus.Unknown = 0 -> JD.Efcpt.Ide.Core.BuildProfileStatus
+JD.Efcpt.Ide.Core.BuildStatusEvaluation
+JD.Efcpt.Ide.Core.BuildStatusEvaluation.BannerMessage.get -> string?
+JD.Efcpt.Ide.Core.BuildStatusEvaluation.BuildStatusEvaluation(JD.Efcpt.Ide.Core.BuildStatusFreshness freshness, string? bannerMessage) -> void
+JD.Efcpt.Ide.Core.BuildStatusEvaluation.Freshness.get -> JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.BuildStatusEvaluator
+JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.BuildStatusFreshness.Current = 1 -> JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.BuildStatusFreshness.NoProfile = 0 -> JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.BuildStatusFreshness.StaleAfterFailedRegenerate = 3 -> JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.BuildStatusFreshness.StaleFromEarlierRun = 2 -> JD.Efcpt.Ide.Core.BuildStatusFreshness
+JD.Efcpt.Ide.Core.JdDiagnostic
+JD.Efcpt.Ide.Core.JdDiagnostic.Code.get -> string!
+JD.Efcpt.Ide.Core.JdDiagnostic.JdDiagnostic(JD.Efcpt.Ide.Core.JdDiagnosticSeverity severity, string! code, string! message) -> void
+JD.Efcpt.Ide.Core.JdDiagnostic.Message.get -> string!
+JD.Efcpt.Ide.Core.JdDiagnostic.Severity.get -> JD.Efcpt.Ide.Core.JdDiagnosticSeverity
+JD.Efcpt.Ide.Core.JdDiagnosticParser
+JD.Efcpt.Ide.Core.JdDiagnosticSeverity
+JD.Efcpt.Ide.Core.JdDiagnosticSeverity.Error = 1 -> JD.Efcpt.Ide.Core.JdDiagnosticSeverity
+JD.Efcpt.Ide.Core.JdDiagnosticSeverity.Warning = 0 -> JD.Efcpt.Ide.Core.JdDiagnosticSeverity
+JD.Efcpt.Ide.Core.ProjectDiscovery
+JD.Efcpt.Ide.Core.ProjectDiscoveryResult
+JD.Efcpt.Ide.Core.ProjectDiscoveryResult.Matches.get -> System.Collections.Generic.IReadOnlyList<string!>!
+JD.Efcpt.Ide.Core.ProjectDiscoveryResult.ProjectDiscoveryResult(System.Collections.Generic.IReadOnlyList<string!>! matches, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Ide.Core.SkippedProject!>! skipped) -> void
+JD.Efcpt.Ide.Core.ProjectDiscoveryResult.Skipped.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Ide.Core.SkippedProject!>!
+JD.Efcpt.Ide.Core.RegenerateAttempt
+JD.Efcpt.Ide.Core.RegenerateAttempt.ExitCode.get -> int
+JD.Efcpt.Ide.Core.RegenerateAttempt.RegenerateAttempt(System.DateTimeOffset startedUtc, bool succeeded, int exitCode) -> void
+JD.Efcpt.Ide.Core.RegenerateAttempt.StartedUtc.get -> System.DateTimeOffset
+JD.Efcpt.Ide.Core.RegenerateAttempt.Succeeded.get -> bool
+JD.Efcpt.Ide.Core.SecretRedaction
+JD.Efcpt.Ide.Core.SkippedProject
+JD.Efcpt.Ide.Core.SkippedProject.Path.get -> string!
+JD.Efcpt.Ide.Core.SkippedProject.Reason.get -> string!
+JD.Efcpt.Ide.Core.SkippedProject.SkippedProject(string! path, string! reason) -> void
+const JD.Efcpt.Ide.Core.BuildProfileReader.SupportedSchemaMajor = 1 -> int
+const JD.Efcpt.Ide.Core.SecretRedaction.ConnectionStringPlaceholder = "<connection-string redacted>" -> string!
+static JD.Efcpt.Ide.Core.BuildProfileReader.IsSchemaSupported(string! schemaVersion) -> bool
+static JD.Efcpt.Ide.Core.BuildProfileReader.NormalizeDiagnostic(JD.Efcpt.Ide.Core.BuildProfileReader.RawDiagnostic! raw) -> JD.Efcpt.Ide.Core.BuildProfileDiagnostic!
+static JD.Efcpt.Ide.Core.BuildProfileReader.Parse(string! jsonText) -> JD.Efcpt.Ide.Core.BuildProfile!
+static JD.Efcpt.Ide.Core.BuildProfileReader.ReadFile(string! path) -> JD.Efcpt.Ide.Core.BuildProfile!
+static JD.Efcpt.Ide.Core.BuildStatusEvaluator.Evaluate(JD.Efcpt.Ide.Core.RegenerateAttempt? lastAttempt, JD.Efcpt.Ide.Core.BuildProfile? profile) -> JD.Efcpt.Ide.Core.BuildStatusEvaluation!
+static JD.Efcpt.Ide.Core.JdDiagnosticParser.ParseLines(string! output) -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Ide.Core.JdDiagnostic!>!
+static JD.Efcpt.Ide.Core.JdDiagnosticParser.TryParseLine(string! line) -> JD.Efcpt.Ide.Core.JdDiagnostic?
+static JD.Efcpt.Ide.Core.ProjectDiscovery.DiscoverJdEfcptProjects(System.Collections.Generic.IReadOnlyList<string!>! csprojPaths, System.Func<string!, string!>! readFile) -> JD.Efcpt.Ide.Core.ProjectDiscoveryResult!
+static JD.Efcpt.Ide.Core.ProjectDiscovery.HasJdEfcptPackageReference(string! csprojContent) -> bool
+static JD.Efcpt.Ide.Core.SecretRedaction.MaskSecrets(string? text) -> string!
+static JD.Efcpt.Ide.Core.SecretRedaction.RedactConnectionString(string? text, string? connectionString) -> string!
+static readonly JD.Efcpt.Ide.Core.JdDiagnosticParser.DiagnosticPattern -> System.Text.RegularExpressions.Regex!
+static readonly JD.Efcpt.Ide.Core.ProjectDiscovery.PackageReferencePattern -> System.Text.RegularExpressions.Regex!

--- a/ide/vs/JD.Efcpt.Ide.Core/PublicAPI.Unshipped.txt
+++ b/ide/vs/JD.Efcpt.Ide.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/JD.Efcpt.Build.Core/JD.Efcpt.Build.Core.csproj
+++ b/src/JD.Efcpt.Build.Core/JD.Efcpt.Build.Core.csproj
@@ -9,6 +9,13 @@
     <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
 
     <!--
+      PublicApiAnalyzers (#191: PUBLIC-API-STABILITY) locks this assembly's public surface.
+      Scoped to net10.0 only; see build/PublicApi.props for why (avoids a per-TFM
+      PublicAPI.*.txt baseline for net472).
+    -->
+    <PublicApiAnalyzerTfm>net10.0</PublicApiAnalyzerTfm>
+
+    <!--
       Not packed as its own NuGet package. This assembly is a build-time/runtime implementation
       detail shared between JD.Efcpt.Build.Tasks and JD.Efcpt.Cli via ProjectReference; its output
       DLL travels to Tasks consumers by being swept up alongside JD.Efcpt.Build.Tasks.dll
@@ -28,6 +35,8 @@
     <Nullable Condition="'$(TargetFramework)' == 'net472'">annotations</Nullable>
     <NoWarn Condition="'$(TargetFramework)' == 'net472'">$(NoWarn);CS8632</NoWarn>
   </PropertyGroup>
+
+  <Import Project="..\..\build\PublicApi.props" />
 
   <!-- Polyfills for net472: provides IsExternalInit, init accessors, etc. (records use these). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/JD.Efcpt.Build.Core/PublicAPI.Shipped.txt
+++ b/src/JD.Efcpt.Build.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,444 @@
+#nullable enable
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.CodeGenerationOverrides!
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.CodeGenerationOverrides() -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.DiscoverMultipleStoredProcedureResultsetsPreview.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.DiscoverMultipleStoredProcedureResultsetsPreview.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.EnableOnConfiguring.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.EnableOnConfiguring.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.Equals(JD.Efcpt.Build.Core.Config.CodeGenerationOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.GenerateMermaidDiagram.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.GenerateMermaidDiagram.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.MergeDacpacs.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.MergeDacpacs.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.RefreshObjectLists.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.RefreshObjectLists.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.RemoveDefaultSqlFromBoolProperties.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.RemoveDefaultSqlFromBoolProperties.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.SoftDeleteObsoleteFiles.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.SoftDeleteObsoleteFiles.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.T4TemplatePath.get -> string?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.T4TemplatePath.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.Type.get -> string?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.Type.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseAlternateStoredProcedureResultsetDiscovery.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseAlternateStoredProcedureResultsetDiscovery.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDataAnnotations.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDataAnnotations.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDatabaseNames.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDatabaseNames.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDatabaseNamesForRoutines.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDatabaseNamesForRoutines.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDecimalDataAnnotationForSprocResults.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseDecimalDataAnnotationForSprocResults.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseInflector.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseInflector.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseInternalAccessModifiersForSprocsAndFunctions.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseInternalAccessModifiersForSprocsAndFunctions.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseLegacyInflector.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseLegacyInflector.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseManyToManyEntity.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseManyToManyEntity.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseNoNavigationsPreview.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseNoNavigationsPreview.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseNullableReferenceTypes.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseNullableReferenceTypes.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UsePrefixNavigationNaming.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UsePrefixNavigationNaming.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseT4.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseT4.init -> void
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseT4Split.get -> bool?
+JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.UseT4Split.init -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigGenerator
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.EfcptConfigOverrides!
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.CodeGeneration.get -> JD.Efcpt.Build.Core.Config.CodeGenerationOverrides?
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.CodeGeneration.init -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.EfcptConfigOverrides() -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Equals(JD.Efcpt.Build.Core.Config.EfcptConfigOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.FileLayout.get -> JD.Efcpt.Build.Core.Config.FileLayoutOverrides?
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.FileLayout.init -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.HasAnyOverrides() -> bool
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Names.get -> JD.Efcpt.Build.Core.Config.NamesOverrides?
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Names.init -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Replacements.get -> JD.Efcpt.Build.Core.Config.ReplacementsOverrides?
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Replacements.init -> void
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.TypeMappings.get -> JD.Efcpt.Build.Core.Config.TypeMappingsOverrides?
+JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.TypeMappings.init -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.FileLayoutOverrides!
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.Equals(JD.Efcpt.Build.Core.Config.FileLayoutOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.FileLayoutOverrides() -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.OutputDbContextPath.get -> string?
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.OutputDbContextPath.init -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.OutputPath.get -> string?
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.OutputPath.init -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.SplitDbContextPreview.get -> bool?
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.SplitDbContextPreview.init -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.UseSchemaFoldersPreview.get -> bool?
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.UseSchemaFoldersPreview.init -> void
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.UseSchemaNamespacesPreview.get -> bool?
+JD.Efcpt.Build.Core.Config.FileLayoutOverrides.UseSchemaNamespacesPreview.init -> void
+JD.Efcpt.Build.Core.Config.NamesOverrides
+JD.Efcpt.Build.Core.Config.NamesOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.NamesOverrides!
+JD.Efcpt.Build.Core.Config.NamesOverrides.DbContextName.get -> string?
+JD.Efcpt.Build.Core.Config.NamesOverrides.DbContextName.init -> void
+JD.Efcpt.Build.Core.Config.NamesOverrides.DbContextNamespace.get -> string?
+JD.Efcpt.Build.Core.Config.NamesOverrides.DbContextNamespace.init -> void
+JD.Efcpt.Build.Core.Config.NamesOverrides.Equals(JD.Efcpt.Build.Core.Config.NamesOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.NamesOverrides.ModelNamespace.get -> string?
+JD.Efcpt.Build.Core.Config.NamesOverrides.ModelNamespace.init -> void
+JD.Efcpt.Build.Core.Config.NamesOverrides.NamesOverrides() -> void
+JD.Efcpt.Build.Core.Config.NamesOverrides.RootNamespace.get -> string?
+JD.Efcpt.Build.Core.Config.NamesOverrides.RootNamespace.init -> void
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.ReplacementsOverrides!
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides.Equals(JD.Efcpt.Build.Core.Config.ReplacementsOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides.PreserveCasingWithRegex.get -> bool?
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides.PreserveCasingWithRegex.init -> void
+JD.Efcpt.Build.Core.Config.ReplacementsOverrides.ReplacementsOverrides() -> void
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.<Clone>$() -> JD.Efcpt.Build.Core.Config.TypeMappingsOverrides!
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.Equals(JD.Efcpt.Build.Core.Config.TypeMappingsOverrides? other) -> bool
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.TypeMappingsOverrides() -> void
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseDateOnlyTimeOnly.get -> bool?
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseDateOnlyTimeOnly.init -> void
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseHierarchyId.get -> bool?
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseHierarchyId.init -> void
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseNodaTime.get -> bool?
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseNodaTime.init -> void
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseSpatial.get -> bool?
+JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.UseSpatial.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionChain
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringName.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringName.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringResolutionContext() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringResolutionContext(string! ExplicitConnectionString, string! EfcptAppSettings, string! EfcptAppConfig, string! ConnectionStringName, string! ProjectDirectory, JD.Efcpt.Build.Core.Logging.IBuildLog! Log, string! ConnectionStringSource = "", System.Collections.Generic.IReadOnlyDictionary<string!, string!>? SourceSettings = null, bool Offline = false, JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSourceResolver? SourceResolver = null) -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringSource.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ConnectionStringSource.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Deconstruct(out string! ExplicitConnectionString, out string! EfcptAppSettings, out string! EfcptAppConfig, out string! ConnectionStringName, out string! ProjectDirectory, out JD.Efcpt.Build.Core.Logging.IBuildLog! Log, out string! ConnectionStringSource, out System.Collections.Generic.IReadOnlyDictionary<string!, string!>? SourceSettings, out bool Offline, out JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSourceResolver? SourceResolver) -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.EfcptAppConfig.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.EfcptAppConfig.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.EfcptAppSettings.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.EfcptAppSettings.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Equals(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext other) -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ExplicitConnectionString.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ExplicitConnectionString.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Log.get -> JD.Efcpt.Build.Core.Logging.IBuildLog!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Log.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Offline.get -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Offline.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ProjectDirectory.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.SourceResolver.get -> JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSourceResolver?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.SourceResolver.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.SourceSettings.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.SourceSettings.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.<Clone>$() -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.ConnectionString.get -> string?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.ConnectionString.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.ConnectionStringResult() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Equals(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult? other) -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.KeyName.get -> string?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.KeyName.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Source.get -> string?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Source.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Success.get -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Success.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.ConnectionStringSourceContext() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.ConnectionStringSourceContext(string! SourceKey, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! Settings, bool Offline, JD.Efcpt.Build.Core.Logging.IBuildLog! Log) -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Deconstruct(out string! SourceKey, out System.Collections.Generic.IReadOnlyDictionary<string!, string!>! Settings, out bool Offline, out JD.Efcpt.Build.Core.Logging.IBuildLog! Log) -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Equals(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext other) -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Log.get -> JD.Efcpt.Build.Core.Logging.IBuildLog!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Log.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Offline.get -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Offline.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Settings.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Settings.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.SourceKey.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.SourceKey.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.Code.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.ConnectionStringSourceException(string! code, string! sourceKey, string! message, System.Exception? innerException = null) -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SourceKey.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.Failed = 3 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.Found = 1 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.Misconfigured = 5 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.NotConfigured = 0 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.NotFound = 2 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome.OfflineBlocked = 4 -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.<Clone>$() -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.ConnectionString.get -> string?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.ConnectionString.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.ConnectionStringSourceResult() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Diagnostic.get -> string?
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Diagnostic.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Equals(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult? other) -> bool
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Outcome.get -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceOutcome
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Outcome.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.SourceKey.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.SourceKey.init -> void
+JD.Efcpt.Build.Core.ConnectionStrings.CoreConnectionStringSourceResolver
+JD.Efcpt.Build.Core.ConnectionStrings.CoreConnectionStringSourceResolver.CoreConnectionStringSourceResolver() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.CoreConnectionStringSourceResolver.Resolve(string! sourceKey) -> JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource?
+JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource
+JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.EnvironmentVariableConnectionStringSource() -> void
+JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.Key.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.Priority.get -> int
+JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.Resolve(in JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext context) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource.Key.get -> string!
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource.Priority.get -> int
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource.Resolve(in JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext context) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSourceResolver
+JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSourceResolver.Resolve(string! sourceKey) -> JD.Efcpt.Build.Core.ConnectionStrings.IConnectionStringSource?
+JD.Efcpt.Build.Core.Diagnostics.DefaultSdkProbe
+JD.Efcpt.Build.Core.Diagnostics.DefaultSdkProbe.DefaultSdkProbe() -> void
+JD.Efcpt.Build.Core.Diagnostics.DefaultSdkProbe.IsDnxAvailable(string! dotnetExe) -> bool
+JD.Efcpt.Build.Core.Diagnostics.DefaultSdkProbe.IsDotNet10SdkInstalled(string! dotnetExe) -> bool
+JD.Efcpt.Build.Core.Diagnostics.DefaultSdkProbe.IsGlobalToolInstalled(string! toolCommand) -> bool
+JD.Efcpt.Build.Core.Diagnostics.DefaultToolAcquirer
+JD.Efcpt.Build.Core.Diagnostics.DefaultToolAcquirer.Acquire(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest request, JD.Efcpt.Build.Core.Logging.IBuildLog! log) -> JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome
+JD.Efcpt.Build.Core.Diagnostics.DefaultToolAcquirer.DefaultToolAcquirer() -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorEngine
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.AutoAcquire.get -> bool
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.AutoAcquire.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Deconstruct(out string! TargetFramework, out string! ToolMode, out string! ToolPackageId, out string! ToolVersion, out string! ToolCommand, out string! ToolPath, out string! DotNetExe, out string! WorkingDirectory, out bool Offline, out bool AutoAcquire, out bool Strict) -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.DoctorInputs() -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.DoctorInputs(string! TargetFramework, string! ToolMode, string! ToolPackageId, string! ToolVersion, string! ToolCommand, string! ToolPath, string! DotNetExe, string! WorkingDirectory, bool Offline, bool AutoAcquire, bool Strict) -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.DotNetExe.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.DotNetExe.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Equals(JD.Efcpt.Build.Core.Diagnostics.DoctorInputs other) -> bool
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Offline.get -> bool
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Offline.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Strict.get -> bool
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Strict.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.TargetFramework.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.TargetFramework.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolCommand.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolCommand.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolMode.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolMode.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolPackageId.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolPackageId.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolPath.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolPath.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolVersion.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToolVersion.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.WorkingDirectory.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.WorkingDirectory.init -> void
+JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities
+JD.Efcpt.Build.Core.Diagnostics.ISdkProbe
+JD.Efcpt.Build.Core.Diagnostics.ISdkProbe.IsDnxAvailable(string! dotnetExe) -> bool
+JD.Efcpt.Build.Core.Diagnostics.ISdkProbe.IsDotNet10SdkInstalled(string! dotnetExe) -> bool
+JD.Efcpt.Build.Core.Diagnostics.ISdkProbe.IsGlobalToolInstalled(string! toolCommand) -> bool
+JD.Efcpt.Build.Core.Diagnostics.IToolAcquirer
+JD.Efcpt.Build.Core.Diagnostics.IToolAcquirer.Acquire(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest request, JD.Efcpt.Build.Core.Logging.IBuildLog! log) -> JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome
+JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome
+JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome.Available = 0 -> JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome
+JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome.Transient = 2 -> JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome
+JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome.Unavailable = 1 -> JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome
+JD.Efcpt.Build.Core.Diagnostics.SdkProbeCache
+JD.Efcpt.Build.Core.Diagnostics.SecretRedaction
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Deconstruct(out bool Success, out string? ErrorMessage) -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Equals(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome other) -> bool
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.ErrorMessage.get -> string?
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.ErrorMessage.init -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Success.get -> bool
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Success.init -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.ToolAcquisitionOutcome() -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.ToolAcquisitionOutcome(bool Success, string? ErrorMessage) -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.Deconstruct(out string! ManifestDir, out string! DotNetExe, out string! ToolPackageId, out string! ToolVersion) -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.DotNetExe.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.DotNetExe.init -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.Equals(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest other) -> bool
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ManifestDir.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ManifestDir.init -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolAcquisitionRequest() -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolAcquisitionRequest(string! ManifestDir, string! DotNetExe, string! ToolPackageId, string! ToolVersion) -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolPackageId.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolPackageId.init -> void
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolVersion.get -> string!
+JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToolVersion.init -> void
+JD.Efcpt.Build.Core.FileHash
+JD.Efcpt.Build.Core.Logging.IBuildLog
+JD.Efcpt.Build.Core.Logging.IBuildLog.Detail(string! message) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Error(string! code, string! message) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Error(string! message) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Info(string! message) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Log(JD.Efcpt.Build.Core.Logging.MessageLevel level, string! message, string? code = null) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Warn(string! code, string! message) -> void
+JD.Efcpt.Build.Core.Logging.IBuildLog.Warn(string! message) -> void
+JD.Efcpt.Build.Core.Logging.MessageLevel
+JD.Efcpt.Build.Core.Logging.MessageLevel.Error = 3 -> JD.Efcpt.Build.Core.Logging.MessageLevel
+JD.Efcpt.Build.Core.Logging.MessageLevel.Info = 1 -> JD.Efcpt.Build.Core.Logging.MessageLevel
+JD.Efcpt.Build.Core.Logging.MessageLevel.None = 0 -> JD.Efcpt.Build.Core.Logging.MessageLevel
+JD.Efcpt.Build.Core.Logging.MessageLevel.Warn = 2 -> JD.Efcpt.Build.Core.Logging.MessageLevel
+JD.Efcpt.Build.Core.Logging.NullBuildLog
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Detail(string! message) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Error(string! code, string! message) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Error(string! message) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Info(string! message) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Log(JD.Efcpt.Build.Core.Logging.MessageLevel level, string! message, string? code = null) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Warn(string! code, string! message) -> void
+JD.Efcpt.Build.Core.Logging.NullBuildLog.Warn(string! message) -> void
+JD.Efcpt.Build.Core.PathUtils
+JD.Efcpt.Build.Core.Processes.ProcessCommand
+JD.Efcpt.Build.Core.Processes.ProcessCommand.Args.get -> string!
+JD.Efcpt.Build.Core.Processes.ProcessCommand.Args.init -> void
+JD.Efcpt.Build.Core.Processes.ProcessCommand.Deconstruct(out string! FileName, out string! Args) -> void
+JD.Efcpt.Build.Core.Processes.ProcessCommand.Equals(JD.Efcpt.Build.Core.Processes.ProcessCommand other) -> bool
+JD.Efcpt.Build.Core.Processes.ProcessCommand.FileName.get -> string!
+JD.Efcpt.Build.Core.Processes.ProcessCommand.FileName.init -> void
+JD.Efcpt.Build.Core.Processes.ProcessCommand.ProcessCommand() -> void
+JD.Efcpt.Build.Core.Processes.ProcessCommand.ProcessCommand(string! FileName, string! Args) -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult
+JD.Efcpt.Build.Core.Processes.ProcessResult.Deconstruct(out int ExitCode, out string! StdOut, out string! StdErr) -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.Equals(JD.Efcpt.Build.Core.Processes.ProcessResult other) -> bool
+JD.Efcpt.Build.Core.Processes.ProcessResult.ExitCode.get -> int
+JD.Efcpt.Build.Core.Processes.ProcessResult.ExitCode.init -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.ProcessResult() -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.ProcessResult(int ExitCode, string! StdOut, string! StdErr) -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.StdErr.get -> string!
+JD.Efcpt.Build.Core.Processes.ProcessResult.StdErr.init -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.StdOut.get -> string!
+JD.Efcpt.Build.Core.Processes.ProcessResult.StdOut.init -> void
+JD.Efcpt.Build.Core.Processes.ProcessResult.Success.get -> bool
+JD.Efcpt.Build.Core.Processes.ProcessRunner
+JD.Efcpt.Build.Core.Providers.ProviderNames
+const JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.OfflineBlockedCode = "JD0032" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SecretNotFoundCode = "JD0031" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SourceMisconfiguredCode = "JD0034" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SourceNotInstalledCode = "JD0033" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SourceResolutionFailedCode = "JD0030" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.DefaultEnvVarName = "EFCPT_CONNECTION_STRING" -> string!
+const JD.Efcpt.Build.Core.ConnectionStrings.EnvironmentVariableConnectionStringSource.EnvVarSettingKey = "envVar" -> string!
+const JD.Efcpt.Build.Core.Diagnostics.SecretRedaction.ConnectionStringPlaceholder = "<connection-string redacted>" -> string!
+override JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.Config.FileLayoutOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.FileLayoutOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.FileLayoutOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.Config.NamesOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.NamesOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.NamesOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.Config.ReplacementsOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.ReplacementsOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.ReplacementsOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.ToString() -> string!
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.GetHashCode() -> int
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.GetHashCode() -> int
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.ToString() -> string!
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.GetHashCode() -> int
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.GetHashCode() -> int
+override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.ToString() -> string!
+override JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Processes.ProcessCommand.GetHashCode() -> int
+override JD.Efcpt.Build.Core.Processes.ProcessResult.GetHashCode() -> int
+static JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.operator !=(JD.Efcpt.Build.Core.Config.CodeGenerationOverrides? left, JD.Efcpt.Build.Core.Config.CodeGenerationOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.CodeGenerationOverrides.operator ==(JD.Efcpt.Build.Core.Config.CodeGenerationOverrides? left, JD.Efcpt.Build.Core.Config.CodeGenerationOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.EfcptConfigGenerator.GenerateFromFile(string! schemaPath, string? dbContextName = null, string? rootNamespace = null, string? schemaUrl = null) -> string!
+static JD.Efcpt.Build.Core.Config.EfcptConfigGenerator.GenerateFromSchema(string! schemaJson, string? dbContextName = null, string? rootNamespace = null, string? schemaUrl = null) -> string!
+static JD.Efcpt.Build.Core.Config.EfcptConfigGenerator.GenerateFromUrlAsync(string? schemaUrl = null, string? dbContextName = null, string? rootNamespace = null, JD.Efcpt.Build.Core.Logging.IBuildLog? log = null) -> System.Threading.Tasks.Task<string!>!
+static JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.operator !=(JD.Efcpt.Build.Core.Config.EfcptConfigOverrides? left, JD.Efcpt.Build.Core.Config.EfcptConfigOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.EfcptConfigOverrides.operator ==(JD.Efcpt.Build.Core.Config.EfcptConfigOverrides? left, JD.Efcpt.Build.Core.Config.EfcptConfigOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.FileLayoutOverrides.operator !=(JD.Efcpt.Build.Core.Config.FileLayoutOverrides? left, JD.Efcpt.Build.Core.Config.FileLayoutOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.FileLayoutOverrides.operator ==(JD.Efcpt.Build.Core.Config.FileLayoutOverrides? left, JD.Efcpt.Build.Core.Config.FileLayoutOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.NamesOverrides.operator !=(JD.Efcpt.Build.Core.Config.NamesOverrides? left, JD.Efcpt.Build.Core.Config.NamesOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.NamesOverrides.operator ==(JD.Efcpt.Build.Core.Config.NamesOverrides? left, JD.Efcpt.Build.Core.Config.NamesOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.ReplacementsOverrides.operator !=(JD.Efcpt.Build.Core.Config.ReplacementsOverrides? left, JD.Efcpt.Build.Core.Config.ReplacementsOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.ReplacementsOverrides.operator ==(JD.Efcpt.Build.Core.Config.ReplacementsOverrides? left, JD.Efcpt.Build.Core.Config.ReplacementsOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.operator !=(JD.Efcpt.Build.Core.Config.TypeMappingsOverrides? left, JD.Efcpt.Build.Core.Config.TypeMappingsOverrides? right) -> bool
+static JD.Efcpt.Build.Core.Config.TypeMappingsOverrides.operator ==(JD.Efcpt.Build.Core.Config.TypeMappingsOverrides? left, JD.Efcpt.Build.Core.Config.TypeMappingsOverrides? right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionChain.Build() -> PatternKit.Behavioral.Chain.ResultChain<JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext, string?>!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.operator !=(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.operator ==(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.Failed() -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.NotFound() -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.WithSuccess(string! connectionString, string! source, string! keyName) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.operator !=(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult? left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult? right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult.operator ==(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult? left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResult? right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.operator !=(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.operator ==(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.KnownSatellitePackagesByKey.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException.SourceNotInstalled(string! sourceKey) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceException!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Failed(string! sourceKey, string? diagnostic = null) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Found(string! sourceKey, string! connectionString) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.Misconfigured(string! sourceKey, string? diagnostic = null) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.NotConfigured(string! sourceKey) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.NotFound(string! sourceKey, string? diagnostic = null) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.OfflineBlocked(string! sourceKey, string? diagnostic = null) -> JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult!
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.operator !=(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult? left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult? right) -> bool
+static JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult.operator ==(JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult? left, JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceResult? right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DoctorEngine.Diagnose(JD.Efcpt.Build.Core.Diagnostics.DoctorInputs inputs, JD.Efcpt.Build.Core.Diagnostics.ISdkProbe! probe) -> (string! Verdict, bool HasViablePath, System.Collections.Generic.IReadOnlyList<string!>! Messages)
+static JD.Efcpt.Build.Core.Diagnostics.DoctorEngine.FindManifestDir(string! start) -> string?
+static JD.Efcpt.Build.Core.Diagnostics.DoctorEngine.IsDotNet10OrLater(string! targetFramework) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DoctorEngine.ManifestListsTool(string! manifestDir, string! toolPackageId, string! toolCommand) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DoctorEngine.ToolModeUsesManifest(string! toolMode, string? manifestDir, bool forceManifestOnNonWindows) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.operator !=(JD.Efcpt.Build.Core.Diagnostics.DoctorInputs left, JD.Efcpt.Build.Core.Diagnostics.DoctorInputs right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.operator ==(JD.Efcpt.Build.Core.Diagnostics.DoctorInputs left, JD.Efcpt.Build.Core.Diagnostics.DoctorInputs right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities.IsDnxAvailable(string! dotnetExe) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities.IsDnxHelpAvailable(string! dotnetExe) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities.IsDotNet10OrLater(string! targetFramework) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities.IsDotNet10SdkInstalled(string! dotnetExe) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.DotNetToolUtilities.ParseTargetFrameworkVersion(string! targetFramework) -> int?
+static JD.Efcpt.Build.Core.Diagnostics.SdkProbeCache.Clear() -> void
+static JD.Efcpt.Build.Core.Diagnostics.SdkProbeCache.GetOrProbe(string! probeName, string? dotnetExe, System.Func<JD.Efcpt.Build.Core.Diagnostics.ProbeOutcome>! probe) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.SdkProbeCache.ResolveDotnetExecutable(string? dotnetExe) -> string?
+static JD.Efcpt.Build.Core.Diagnostics.SecretRedaction.MaskSecrets(string? text) -> string!
+static JD.Efcpt.Build.Core.Diagnostics.SecretRedaction.RedactConnectionString(string? text, string? connectionString) -> string!
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Failed(string! errorMessage) -> JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Ok() -> JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.operator !=(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome left, JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.operator ==(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome left, JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.operator !=(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest left, JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest right) -> bool
+static JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.operator ==(JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest left, JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest right) -> bool
+static JD.Efcpt.Build.Core.FileHash.HashBytes(byte[]! bytes) -> string!
+static JD.Efcpt.Build.Core.FileHash.HashFile(string! path) -> string!
+static JD.Efcpt.Build.Core.FileHash.HashString(string! content) -> string!
+static JD.Efcpt.Build.Core.PathUtils.FullPath(string! path, string! baseDir) -> string!
+static JD.Efcpt.Build.Core.PathUtils.HasExplicitPath(string? s) -> bool
+static JD.Efcpt.Build.Core.PathUtils.HasValue(string? s) -> bool
+static JD.Efcpt.Build.Core.Processes.ProcessCommand.operator !=(JD.Efcpt.Build.Core.Processes.ProcessCommand left, JD.Efcpt.Build.Core.Processes.ProcessCommand right) -> bool
+static JD.Efcpt.Build.Core.Processes.ProcessCommand.operator ==(JD.Efcpt.Build.Core.Processes.ProcessCommand left, JD.Efcpt.Build.Core.Processes.ProcessCommand right) -> bool
+static JD.Efcpt.Build.Core.Processes.ProcessResult.operator !=(JD.Efcpt.Build.Core.Processes.ProcessResult left, JD.Efcpt.Build.Core.Processes.ProcessResult right) -> bool
+static JD.Efcpt.Build.Core.Processes.ProcessResult.operator ==(JD.Efcpt.Build.Core.Processes.ProcessResult left, JD.Efcpt.Build.Core.Processes.ProcessResult right) -> bool
+static JD.Efcpt.Build.Core.Processes.ProcessRunner.Run(JD.Efcpt.Build.Core.Logging.IBuildLog! log, string! fileName, string! args, string! workingDir, System.Collections.Generic.IDictionary<string!, string!>? environmentVariables = null, int? timeoutMs = null, string? secretToRedact = null) -> JD.Efcpt.Build.Core.Processes.ProcessResult
+static JD.Efcpt.Build.Core.Processes.ProcessRunner.RunBuildOrThrow(JD.Efcpt.Build.Core.Logging.IBuildLog! log, string! fileName, string! args, string! workingDir, string? errorMessage = null, System.Collections.Generic.IDictionary<string!, string!>? environmentVariables = null) -> void
+static JD.Efcpt.Build.Core.Processes.ProcessRunner.RunOrThrow(JD.Efcpt.Build.Core.Logging.IBuildLog! log, string! fileName, string! args, string! workingDir, System.Collections.Generic.IDictionary<string!, string!>? environmentVariables = null, string? secretToRedact = null) -> void
+static JD.Efcpt.Build.Core.Providers.ProviderNames.GetDisplayName(string! provider) -> string!
+static JD.Efcpt.Build.Core.Providers.ProviderNames.Normalize(string! provider) -> string!
+static JD.Efcpt.Build.Core.Providers.ProviderNames.SupportedProviders.get -> System.Collections.Generic.IReadOnlyList<string!>!
+static readonly JD.Efcpt.Build.Core.Logging.NullBuildLog.Instance -> JD.Efcpt.Build.Core.Logging.NullBuildLog!
+~override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringResolutionContext.ToString() -> string
+~override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.ConnectionStrings.ConnectionStringSourceContext.ToString() -> string
+~override JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.Diagnostics.DoctorInputs.ToString() -> string
+~override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionOutcome.ToString() -> string
+~override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.Diagnostics.ToolAcquisitionRequest.ToString() -> string
+~override JD.Efcpt.Build.Core.Processes.ProcessCommand.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.Processes.ProcessCommand.ToString() -> string
+~override JD.Efcpt.Build.Core.Processes.ProcessResult.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Core.Processes.ProcessResult.ToString() -> string

--- a/src/JD.Efcpt.Build.Core/PublicAPI.Unshipped.txt
+++ b/src/JD.Efcpt.Build.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/JD.Efcpt.Build.Providers.Abstractions/JD.Efcpt.Build.Providers.Abstractions.csproj
+++ b/src/JD.Efcpt.Build.Providers.Abstractions/JD.Efcpt.Build.Providers.Abstractions.csproj
@@ -10,6 +10,13 @@
     <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
 
     <!--
+      PublicApiAnalyzers (#191: PUBLIC-API-STABILITY) locks this assembly's public surface -
+      it is the custom-provider contract third parties reference. Scoped to net10.0 only; see
+      build/PublicApi.props for why (avoids a per-TFM PublicAPI.*.txt baseline for net472).
+    -->
+    <PublicApiAnalyzerTfm>net10.0</PublicApiAnalyzerTfm>
+
+    <!--
       Referenceable as its own NuGet package (#184): third-party authors implementing a custom
       database provider (IProviderAdapter + ISchemaReader) need something installable to compile
       against, without pulling in all of JD.Efcpt.Build.Tasks. This assembly remains the shared
@@ -49,6 +56,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
+
+  <Import Project="..\..\build\PublicApi.props" />
 
   <!-- Polyfills for net472: provides IsExternalInit, init accessors, etc. (records use these). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/JD.Efcpt.Build.Providers.Abstractions/PublicAPI.Shipped.txt
+++ b/src/JD.Efcpt.Build.Providers.Abstractions/PublicAPI.Shipped.txt
@@ -1,0 +1,210 @@
+#nullable enable
+JD.Efcpt.Build.Tasks.Extensions.DataRowExtensions
+JD.Efcpt.Build.Tasks.Extensions.StringExtensions
+JD.Efcpt.Build.Tasks.Schema.ColumnModel
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.ColumnModel!
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.ColumnModel(string! Name, string! DataType, int MaxLength, int Precision, int Scale, bool IsNullable, int OrdinalPosition, string? DefaultValue) -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.DataType.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.DataType.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Deconstruct(out string! Name, out string! DataType, out int MaxLength, out int Precision, out int Scale, out bool IsNullable, out int OrdinalPosition, out string? DefaultValue) -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.DefaultValue.get -> string?
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.DefaultValue.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Equals(JD.Efcpt.Build.Tasks.Schema.ColumnModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.IsNullable.get -> bool
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.IsNullable.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.MaxLength.get -> int
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.MaxLength.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Name.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Name.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.OrdinalPosition.get -> int
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.OrdinalPosition.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Precision.get -> int
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Precision.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Scale.get -> int
+JD.Efcpt.Build.Tasks.Schema.ColumnModel.Scale.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.ColumnName.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.ColumnName.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.ColumnNameMapping(string! TableSchema, string! TableName, string! ColumnName, string! DataType, string! MaxLength, string! Precision, string! Scale, string! IsNullable, string! OrdinalPosition, string! DefaultValue) -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.DataType.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.DataType.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Deconstruct(out string! TableSchema, out string! TableName, out string! ColumnName, out string! DataType, out string! MaxLength, out string! Precision, out string! Scale, out string! IsNullable, out string! OrdinalPosition, out string! DefaultValue) -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.DefaultValue.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.DefaultValue.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Equals(JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.IsNullable.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.IsNullable.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.MaxLength.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.MaxLength.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.OrdinalPosition.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.OrdinalPosition.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Precision.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Precision.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Scale.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Scale.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.TableName.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.TableName.init -> void
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.TableSchema.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.TableSchema.init -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.ConstraintModel!
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.CheckExpression.get -> string?
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.CheckExpression.init -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.ConstraintModel(string! Name, JD.Efcpt.Build.Tasks.Schema.ConstraintType Type, string? CheckExpression, JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? ForeignKey) -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Deconstruct(out string! Name, out JD.Efcpt.Build.Tasks.Schema.ConstraintType Type, out string? CheckExpression, out JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? ForeignKey) -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Equals(JD.Efcpt.Build.Tasks.Schema.ConstraintModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.ForeignKey.get -> JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel?
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.ForeignKey.init -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Name.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Name.init -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Type.get -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Type.init -> void
+JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintType.Check = 2 -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintType.Default = 3 -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintType.ForeignKey = 1 -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintType.PrimaryKey = 0 -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ConstraintType.Unique = 4 -> JD.Efcpt.Build.Tasks.Schema.ConstraintType
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ColumnName.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ColumnName.init -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.Deconstruct(out string! ColumnName, out string! ReferencedColumnName, out int OrdinalPosition) -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.Equals(JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ForeignKeyColumnModel(string! ColumnName, string! ReferencedColumnName, int OrdinalPosition) -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.OrdinalPosition.get -> int
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.OrdinalPosition.init -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ReferencedColumnName.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ReferencedColumnName.init -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Columns.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel!>!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Columns.init -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Deconstruct(out string! ReferencedSchema, out string! ReferencedTable, out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel!>! Columns) -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Equals(JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ForeignKeyModel(string! ReferencedSchema, string! ReferencedTable, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel!>! Columns) -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ReferencedSchema.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ReferencedSchema.init -> void
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ReferencedTable.get -> string!
+JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ReferencedTable.init -> void
+JD.Efcpt.Build.Tasks.Schema.IProviderAdapter
+JD.Efcpt.Build.Tasks.Schema.IProviderAdapter.CreateConnection(string! connectionString) -> System.Data.Common.DbConnection!
+JD.Efcpt.Build.Tasks.Schema.IProviderAdapter.CreateSchemaReader() -> JD.Efcpt.Build.Tasks.Schema.ISchemaReader!
+JD.Efcpt.Build.Tasks.Schema.ISchemaReader
+JD.Efcpt.Build.Tasks.Schema.ISchemaReader.ReadSchema(string! connectionString) -> JD.Efcpt.Build.Tasks.Schema.SchemaModel!
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.IndexColumnModel!
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.ColumnName.get -> string!
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.ColumnName.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.Deconstruct(out string! ColumnName, out int OrdinalPosition, out bool IsDescending) -> void
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.Equals(JD.Efcpt.Build.Tasks.Schema.IndexColumnModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.IndexColumnModel(string! ColumnName, int OrdinalPosition, bool IsDescending) -> void
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.IsDescending.get -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.IsDescending.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.OrdinalPosition.get -> int
+JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.OrdinalPosition.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel
+JD.Efcpt.Build.Tasks.Schema.IndexModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.IndexModel!
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Columns.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexColumnModel!>!
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Columns.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Deconstruct(out string! Name, out bool IsUnique, out bool IsPrimaryKey, out bool IsClustered, out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexColumnModel!>! Columns) -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Equals(JD.Efcpt.Build.Tasks.Schema.IndexModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IndexModel(string! Name, bool IsUnique, bool IsPrimaryKey, bool IsClustered, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexColumnModel!>! Columns) -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsClustered.get -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsClustered.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsPrimaryKey.get -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsPrimaryKey.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsUnique.get -> bool
+JD.Efcpt.Build.Tasks.Schema.IndexModel.IsUnique.init -> void
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Name.get -> string!
+JD.Efcpt.Build.Tasks.Schema.IndexModel.Name.init -> void
+JD.Efcpt.Build.Tasks.Schema.SchemaModel
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.SchemaModel!
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.Deconstruct(out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.TableModel!>! Tables) -> void
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.Equals(JD.Efcpt.Build.Tasks.Schema.SchemaModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.SchemaModel(System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.TableModel!>! Tables) -> void
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.Tables.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.TableModel!>!
+JD.Efcpt.Build.Tasks.Schema.SchemaModel.Tables.init -> void
+JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase
+JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.ReadSchema(string! connectionString) -> JD.Efcpt.Build.Tasks.Schema.SchemaModel!
+JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.SchemaReaderBase() -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel
+JD.Efcpt.Build.Tasks.Schema.TableModel.<Clone>$() -> JD.Efcpt.Build.Tasks.Schema.TableModel!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Columns.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ColumnModel!>!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Columns.init -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.Constraints.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ConstraintModel!>!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Constraints.init -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.Deconstruct(out string! Schema, out string! Name, out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ColumnModel!>! Columns, out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexModel!>! Indexes, out System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ConstraintModel!>! Constraints) -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.Equals(JD.Efcpt.Build.Tasks.Schema.TableModel? other) -> bool
+JD.Efcpt.Build.Tasks.Schema.TableModel.Indexes.get -> System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexModel!>!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Indexes.init -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.Name.get -> string!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Name.init -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.Schema.get -> string!
+JD.Efcpt.Build.Tasks.Schema.TableModel.Schema.init -> void
+JD.Efcpt.Build.Tasks.Schema.TableModel.TableModel(string! Schema, string! Name, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ColumnModel!>! Columns, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.IndexModel!>! Indexes, System.Collections.Generic.IReadOnlyList<JD.Efcpt.Build.Tasks.Schema.ConstraintModel!>! Constraints) -> void
+abstract JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.CreateConnection(string! connectionString) -> System.Data.Common.DbConnection!
+abstract JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetUserTables(System.Data.Common.DbConnection! connection) -> System.Collections.Generic.List<(string! Schema, string! Name)>!
+abstract JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.ReadIndexesForTable(System.Data.DataTable! indexesData, System.Data.DataTable! indexColumnsData, string! schemaName, string! tableName) -> System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.IndexModel!>!
+override JD.Efcpt.Build.Tasks.Schema.ColumnModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.ColumnModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.ColumnModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.ConstraintModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.ConstraintModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.ConstraintModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.IndexModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.IndexModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.IndexModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.SchemaModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.SchemaModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.SchemaModel.ToString() -> string!
+override JD.Efcpt.Build.Tasks.Schema.TableModel.Equals(object? obj) -> bool
+override JD.Efcpt.Build.Tasks.Schema.TableModel.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Schema.TableModel.ToString() -> string!
+static JD.Efcpt.Build.Tasks.Extensions.DataRowExtensions.GetString(this System.Data.DataRow! row, string! columnName) -> string!
+static JD.Efcpt.Build.Tasks.Extensions.StringExtensions.EqualsIgnoreCase(this string? str, string? other) -> bool
+static JD.Efcpt.Build.Tasks.Extensions.StringExtensions.IsTrue(this string? str) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ColumnModel.operator !=(JD.Efcpt.Build.Tasks.Schema.ColumnModel? left, JD.Efcpt.Build.Tasks.Schema.ColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ColumnModel.operator ==(JD.Efcpt.Build.Tasks.Schema.ColumnModel? left, JD.Efcpt.Build.Tasks.Schema.ColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.operator !=(JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping? left, JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping.operator ==(JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping? left, JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ConstraintModel.operator !=(JD.Efcpt.Build.Tasks.Schema.ConstraintModel? left, JD.Efcpt.Build.Tasks.Schema.ConstraintModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ConstraintModel.operator ==(JD.Efcpt.Build.Tasks.Schema.ConstraintModel? left, JD.Efcpt.Build.Tasks.Schema.ConstraintModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.operator !=(JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel? left, JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel.operator ==(JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel? left, JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.Create(string! referencedSchema, string! referencedTable, System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.ForeignKeyColumnModel!>! columns) -> JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel!
+static JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.operator !=(JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? left, JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel.operator ==(JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? left, JD.Efcpt.Build.Tasks.Schema.ForeignKeyModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.operator !=(JD.Efcpt.Build.Tasks.Schema.IndexColumnModel? left, JD.Efcpt.Build.Tasks.Schema.IndexColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.IndexColumnModel.operator ==(JD.Efcpt.Build.Tasks.Schema.IndexColumnModel? left, JD.Efcpt.Build.Tasks.Schema.IndexColumnModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.IndexModel.Create(string! name, bool isUnique, bool isPrimaryKey, bool isClustered, System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.IndexColumnModel!>! columns) -> JD.Efcpt.Build.Tasks.Schema.IndexModel!
+static JD.Efcpt.Build.Tasks.Schema.IndexModel.operator !=(JD.Efcpt.Build.Tasks.Schema.IndexModel? left, JD.Efcpt.Build.Tasks.Schema.IndexModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.IndexModel.operator ==(JD.Efcpt.Build.Tasks.Schema.IndexModel? left, JD.Efcpt.Build.Tasks.Schema.IndexModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.SchemaModel.Create(System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.TableModel!>! tables) -> JD.Efcpt.Build.Tasks.Schema.SchemaModel!
+static JD.Efcpt.Build.Tasks.Schema.SchemaModel.Empty.get -> JD.Efcpt.Build.Tasks.Schema.SchemaModel!
+static JD.Efcpt.Build.Tasks.Schema.SchemaModel.operator !=(JD.Efcpt.Build.Tasks.Schema.SchemaModel? left, JD.Efcpt.Build.Tasks.Schema.SchemaModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.SchemaModel.operator ==(JD.Efcpt.Build.Tasks.Schema.SchemaModel? left, JD.Efcpt.Build.Tasks.Schema.SchemaModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.EscapeSql(string! value) -> string!
+static JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetColumnName(System.Data.DataTable! table, params string![]! candidates) -> string!
+static JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetExistingColumn(System.Data.DataTable! table, params string![]! candidates) -> string?
+static JD.Efcpt.Build.Tasks.Schema.TableModel.Create(string! schema, string! name, System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.ColumnModel!>! columns, System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.IndexModel!>! indexes, System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.ConstraintModel!>! constraints) -> JD.Efcpt.Build.Tasks.Schema.TableModel!
+static JD.Efcpt.Build.Tasks.Schema.TableModel.operator !=(JD.Efcpt.Build.Tasks.Schema.TableModel? left, JD.Efcpt.Build.Tasks.Schema.TableModel? right) -> bool
+static JD.Efcpt.Build.Tasks.Schema.TableModel.operator ==(JD.Efcpt.Build.Tasks.Schema.TableModel? left, JD.Efcpt.Build.Tasks.Schema.TableModel? right) -> bool
+virtual JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetColumnMapping() -> JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping!
+virtual JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetIndexColumns(System.Data.Common.DbConnection! connection) -> System.Data.DataTable!
+virtual JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.GetIndexes(System.Data.Common.DbConnection! connection) -> System.Data.DataTable!
+virtual JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.MatchesTable(System.Data.DataRow! row, JD.Efcpt.Build.Tasks.Schema.ColumnNameMapping! mapping, string! schemaName, string! tableName) -> bool
+virtual JD.Efcpt.Build.Tasks.Schema.SchemaReaderBase.ReadColumnsForTable(System.Data.DataTable! columnsData, string! schemaName, string! tableName) -> System.Collections.Generic.IEnumerable<JD.Efcpt.Build.Tasks.Schema.ColumnModel!>!

--- a/src/JD.Efcpt.Build.Providers.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/JD.Efcpt.Build.Providers.Abstractions/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/JD.Efcpt.Build.Providers.Abstractions/packages.lock.json
+++ b/src/JD.Efcpt.Build.Providers.Abstractions/packages.lock.json
@@ -9,7 +9,14 @@
         "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
       }
     },
-    "net10.0": {},
+    "net10.0": {
+      "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "W4kJGezNIKLzo0Ak5FAQDFvkMf2U7DtGL4THmHyRSApfKsKt5V+eX/bU0ZLKAt/uf9Bb2o1bi0YDKj/GRB/vYQ=="
+      }
+    },
     "net8.0": {},
     "net9.0": {}
   }

--- a/src/JD.Efcpt.Build.Tasks/JD.Efcpt.Build.Tasks.csproj
+++ b/src/JD.Efcpt.Build.Tasks/JD.Efcpt.Build.Tasks.csproj
@@ -2,6 +2,13 @@
   <PropertyGroup>
     <!-- Multi-target for Framework MSBuild (net472) and .NET Core MSBuild (net8.0+) -->
     <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <!--
+      PublicApiAnalyzers (#191: PUBLIC-API-STABILITY) locks this assembly's public surface.
+      Scoped to net10.0 only; see build/PublicApi.props for why (avoids a per-TFM
+      PublicAPI.*.txt baseline for net472).
+    -->
+    <PublicApiAnalyzerTfm>net10.0</PublicApiAnalyzerTfm>
     <IsPackable>false</IsPackable>
     <AssemblyName>JD.Efcpt.Build.Tasks</AssemblyName>
     <RootNamespace>JD.Efcpt.Build.Tasks</RootNamespace>
@@ -27,6 +34,8 @@
     -->
     <GenerateDependencyFile>true</GenerateDependencyFile>
   </PropertyGroup>
+
+  <Import Project="..\..\build\PublicApi.props" />
 
   <ItemGroup>
     <!--

--- a/src/JD.Efcpt.Build.Tasks/PublicAPI.Shipped.txt
+++ b/src/JD.Efcpt.Build.Tasks/PublicAPI.Shipped.txt
@@ -1,0 +1,832 @@
+#nullable enable
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.AddSqlFileWarnings() -> void
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.DatabaseName.get -> string!
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.DatabaseName.set -> void
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.FilesProcessed.get -> int
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.FilesProcessed.set -> void
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.ScriptsDirectory.get -> string!
+JD.Efcpt.Build.Tasks.AddSqlFileWarnings.ScriptsDirectory.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ApplyConfigOverrides() -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ApplyOverrides.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ApplyOverrides.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextName.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextName.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextNamespace.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextNamespace.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextOutputPath.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DbContextOutputPath.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DiscoverMultipleResultSets.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.DiscoverMultipleResultSets.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.EnableOnConfiguring.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.EnableOnConfiguring.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.GenerateMermaidDiagram.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.GenerateMermaidDiagram.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.GenerationType.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.GenerationType.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.IsUsingDefaultConfig.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.IsUsingDefaultConfig.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.MergeDacpacs.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.MergeDacpacs.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ModelNamespace.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ModelNamespace.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.OutputPath.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.OutputPath.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.PreserveCasingWithRegex.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.PreserveCasingWithRegex.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RefreshObjectLists.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RefreshObjectLists.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RemoveDefaultSqlFromBool.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RemoveDefaultSqlFromBool.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RootNamespace.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.RootNamespace.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.SoftDeleteObsoleteFiles.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.SoftDeleteObsoleteFiles.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.SplitDbContext.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.SplitDbContext.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.StagedConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.StagedConfigPath.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.T4TemplatePath.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.T4TemplatePath.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseAlternateResultSetDiscovery.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseAlternateResultSetDiscovery.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDataAnnotations.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDataAnnotations.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDatabaseNames.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDatabaseNames.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDatabaseNamesForRoutines.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDatabaseNamesForRoutines.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDateOnlyTimeOnly.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDateOnlyTimeOnly.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDecimalAnnotationForSprocs.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseDecimalAnnotationForSprocs.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseHierarchyId.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseHierarchyId.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseInflector.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseInflector.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseInternalAccessForRoutines.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseInternalAccessForRoutines.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseLegacyInflector.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseLegacyInflector.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseManyToManyEntity.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseManyToManyEntity.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNoNavigations.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNoNavigations.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNodaTime.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNodaTime.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNullableReferenceTypes.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseNullableReferenceTypes.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UsePrefixNavigationNaming.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UsePrefixNavigationNaming.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSchemaFolders.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSchemaFolders.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSchemaNamespaces.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSchemaNamespaces.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSpatial.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseSpatial.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseT4.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseT4.set -> void
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseT4Split.get -> string!
+JD.Efcpt.Build.Tasks.ApplyConfigOverrides.UseT4Split.set -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.Deconstruct(out string! OverridePath, out string! ProjectDirectory, out string! SolutionDir, out bool ProbeSolutionDir, out string! DefaultsRoot, out System.Collections.Generic.IReadOnlyList<string!>! DirNames) -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DefaultsRoot.get -> string!
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DefaultsRoot.init -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DirNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DirNames.init -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DirectoryResolutionContext() -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.DirectoryResolutionContext(string! OverridePath, string! ProjectDirectory, string! SolutionDir, bool ProbeSolutionDir, string! DefaultsRoot, System.Collections.Generic.IReadOnlyList<string!>! DirNames) -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.Equals(JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext other) -> bool
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.OverridePath.get -> string!
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.OverridePath.init -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.ProbeSolutionDir.get -> bool
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.ProbeSolutionDir.init -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.ProjectDirectory.init -> void
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.SolutionDir.get -> string!
+JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.SolutionDir.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.Deconstruct(out string! OverridePath, out string! ProjectDirectory, out string! SolutionDir, out bool ProbeSolutionDir, out string! DefaultsRoot, out System.Collections.Generic.IReadOnlyList<string!>! FileNames) -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.DefaultsRoot.get -> string!
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.DefaultsRoot.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.Equals(JD.Efcpt.Build.Tasks.Chains.FileResolutionContext other) -> bool
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.FileNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.FileNames.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.FileResolutionContext() -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.FileResolutionContext(string! OverridePath, string! ProjectDirectory, string! SolutionDir, bool ProbeSolutionDir, string! DefaultsRoot, System.Collections.Generic.IReadOnlyList<string!>! FileNames) -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.OverridePath.get -> string!
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.OverridePath.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.ProbeSolutionDir.get -> bool
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.ProbeSolutionDir.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.ProjectDirectory.init -> void
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.SolutionDir.get -> string!
+JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.SolutionDir.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.Deconstruct(out string! OverridePath, out string! ProjectDirectory, out string! SolutionDir, out bool ProbeSolutionDir, out string! DefaultsRoot, out System.Collections.Generic.IReadOnlyList<string!>! ResourceNames) -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.DefaultsRoot.get -> string!
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.DefaultsRoot.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.Equals(JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext other) -> bool
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.OverridePath.get -> string!
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.OverridePath.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ProbeSolutionDir.get -> bool
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ProbeSolutionDir.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ProjectDirectory.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ResourceNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ResourceNames.init -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ResourceResolutionContext() -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ResourceResolutionContext(string! OverridePath, string! ProjectDirectory, string! SolutionDir, bool ProbeSolutionDir, string! DefaultsRoot, System.Collections.Generic.IReadOnlyList<string!>! ResourceNames) -> void
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.SolutionDir.get -> string!
+JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.SolutionDir.init -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion
+JD.Efcpt.Build.Tasks.CheckSdkVersion.CacheHours.get -> int
+JD.Efcpt.Build.Tasks.CheckSdkVersion.CacheHours.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.CheckSdkVersion() -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.CurrentVersion.get -> string!
+JD.Efcpt.Build.Tasks.CheckSdkVersion.CurrentVersion.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.ForceCheck.get -> bool
+JD.Efcpt.Build.Tasks.CheckSdkVersion.ForceCheck.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.LatestVersion.get -> string!
+JD.Efcpt.Build.Tasks.CheckSdkVersion.LatestVersion.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.PackageId.get -> string!
+JD.Efcpt.Build.Tasks.CheckSdkVersion.PackageId.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.CheckSdkVersion.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.UpdateAvailable.get -> bool
+JD.Efcpt.Build.Tasks.CheckSdkVersion.UpdateAvailable.set -> void
+JD.Efcpt.Build.Tasks.CheckSdkVersion.WarningLevel.get -> string!
+JD.Efcpt.Build.Tasks.CheckSdkVersion.WarningLevel.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ComputeFingerprint() -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ConfigPath.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ConfigPropertyOverrides.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ConfigPropertyOverrides.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.DacpacPath.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.DetectGeneratedFileChanges.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.DetectGeneratedFileChanges.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.Fingerprint.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.Fingerprint.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.FingerprintFile.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.FingerprintFile.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.GeneratedDir.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.GeneratedDir.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.HasChanged.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.HasChanged.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.RenamingPath.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.RenamingPath.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.SchemaFingerprint.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.SchemaFingerprint.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.TemplateDir.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.TemplateDir.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ToolVersion.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.ToolVersion.set -> void
+JD.Efcpt.Build.Tasks.ComputeFingerprint.UseConnectionStringMode.get -> string!
+JD.Efcpt.Build.Tasks.ComputeFingerprint.UseConnectionStringMode.set -> void
+JD.Efcpt.Build.Tasks.DbContextNameGenerator
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute.Exclude.get -> bool
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute.Exclude.set -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute.Name.get -> string?
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute.Name.set -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfileInputAttribute.ProfileInputAttribute() -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute.Exclude.get -> bool
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute.Exclude.set -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute.Name.get -> string?
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute.Name.set -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfileOutputAttribute.ProfileOutputAttribute() -> void
+JD.Efcpt.Build.Tasks.Decorators.ProfilingBehavior
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Deconstruct(out Microsoft.Build.Utilities.TaskLoggingHelper! Logger, out string! TaskName, out JD.Efcpt.Build.Tasks.Profiling.BuildProfiler? Profiler) -> void
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Equals(JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext other) -> bool
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Logger.get -> Microsoft.Build.Utilities.TaskLoggingHelper!
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Logger.init -> void
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Profiler.get -> JD.Efcpt.Build.Tasks.Profiling.BuildProfiler?
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Profiler.init -> void
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.TaskExecutionContext() -> void
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.TaskExecutionContext(Microsoft.Build.Utilities.TaskLoggingHelper! Logger, string! TaskName, JD.Efcpt.Build.Tasks.Profiling.BuildProfiler? Profiler = null) -> void
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.TaskName.get -> string!
+JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.TaskName.init -> void
+JD.Efcpt.Build.Tasks.DetectSqlProject
+JD.Efcpt.Build.Tasks.DetectSqlProject.DSP.get -> string?
+JD.Efcpt.Build.Tasks.DetectSqlProject.DSP.set -> void
+JD.Efcpt.Build.Tasks.DetectSqlProject.DetectSqlProject() -> void
+JD.Efcpt.Build.Tasks.DetectSqlProject.IsSqlProject.get -> bool
+JD.Efcpt.Build.Tasks.DetectSqlProject.ProjectPath.get -> string?
+JD.Efcpt.Build.Tasks.DetectSqlProject.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.DetectSqlProject.SqlServerVersion.get -> string?
+JD.Efcpt.Build.Tasks.DetectSqlProject.SqlServerVersion.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor
+JD.Efcpt.Build.Tasks.EfcptDoctor.AutoAcquireTool.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.AutoAcquireTool.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.DotNetExe.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.DotNetExe.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.EfcptDoctor() -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.HasViablePath.get -> bool
+JD.Efcpt.Build.Tasks.EfcptDoctor.HasViablePath.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.Messages.get -> string![]!
+JD.Efcpt.Build.Tasks.EfcptDoctor.Messages.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.OfflineMode.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.OfflineMode.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.Strict.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.Strict.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.TargetFramework.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolCommand.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolCommand.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolMode.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolMode.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolPackageId.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolPackageId.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolPath.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolPath.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolVersion.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.ToolVersion.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.Verdict.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.Verdict.set -> void
+JD.Efcpt.Build.Tasks.EfcptDoctor.WorkingDirectory.get -> string!
+JD.Efcpt.Build.Tasks.EfcptDoctor.WorkingDirectory.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.Configuration.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.Configuration.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.DacpacPath.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.DotNetExe.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.DotNetExe.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.EnsureDacpacBuilt() -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.MsBuildExe.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.MsBuildExe.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.SqlProjPath.get -> string!
+JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.SqlProjPath.set -> void
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.BuildSucceeded.get -> bool
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.BuildSucceeded.set -> void
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.FinalizeBuildProfiling() -> void
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.OutputPath.get -> string!
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.OutputPath.set -> void
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ConfigPath.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ConfigPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.Configuration.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.Configuration.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.DacpacPath.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.EnableProfiling.get -> string!
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.EnableProfiling.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.InitializeBuildProfiling() -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ProjectName.get -> string!
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ProjectName.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.Provider.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.Provider.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.RenamingPath.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.RenamingPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.SqlProjectPath.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.SqlProjectPath.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.TargetFramework.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.TemplateDir.get -> string?
+JD.Efcpt.Build.Tasks.InitializeBuildProfiling.TemplateDir.set -> void
+JD.Efcpt.Build.Tasks.MessageLevelHelpers
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.ArtifactInfo() -> void
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Hash.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Hash.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Path.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Path.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Size.get -> long?
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Size.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Type.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo.Type.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.BuildConfiguration() -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.ConfigPath.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.ConfigPath.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.ConnectionString.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.ConnectionString.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.DacpacPath.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.Provider.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.Provider.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.RenamingPath.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.RenamingPath.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.SqlProjectPath.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.SqlProjectPath.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.TemplateDir.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration.TemplateDir.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.BuildGraph() -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.FailedTasks.get -> int
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.FailedTasks.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.Nodes.get -> System.Collections.Generic.List<JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode!>!
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.Nodes.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.SkippedTasks.get -> int
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.SkippedTasks.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.SuccessfulTasks.get -> int
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.SuccessfulTasks.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.TotalTasks.get -> int
+JD.Efcpt.Build.Tasks.Profiling.BuildGraph.TotalTasks.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.BuildGraphNode() -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Children.get -> System.Collections.Generic.List<JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode!>!
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Children.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Id.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Id.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.ParentId.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.ParentId.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Task.get -> JD.Efcpt.Build.Tasks.Profiling.TaskExecution!
+JD.Efcpt.Build.Tasks.Profiling.BuildGraphNode.Task.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.AddArtifact(JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo! artifact) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.AddDiagnostic(JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel level, string! message, string? code = null) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.AddMetadata(string! key, object? value) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.BeginTask(string! taskName, string? initiator = null, System.Collections.Generic.Dictionary<string!, object?>? inputs = null) -> JD.Efcpt.Build.Tasks.Profiling.ITaskTracker!
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.BuildProfiler(bool enabled, string! projectPath, string! projectName, string? targetFramework = null, string? configuration = null) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.Complete(string! outputPath) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.Enabled.get -> bool
+JD.Efcpt.Build.Tasks.Profiling.BuildProfiler.SetConfiguration(JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration! config) -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildProfilerManager
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Artifacts.get -> System.Collections.Generic.List<JD.Efcpt.Build.Tasks.Profiling.ArtifactInfo!>!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Artifacts.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.BuildGraph.get -> JD.Efcpt.Build.Tasks.Profiling.BuildGraph!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.BuildGraph.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.BuildRunOutput() -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Configuration.get -> JD.Efcpt.Build.Tasks.Profiling.BuildConfiguration!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Configuration.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Diagnostics.get -> System.Collections.Generic.List<JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage!>!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Diagnostics.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Duration.get -> System.TimeSpan
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Duration.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.EndTime.get -> System.DateTimeOffset?
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.EndTime.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Metadata.get -> System.Collections.Generic.Dictionary<string!, object?>!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Metadata.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Project.get -> JD.Efcpt.Build.Tasks.Profiling.ProjectInfo!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Project.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.RunId.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.RunId.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.SchemaVersion.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.SchemaVersion.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.StartTime.get -> System.DateTimeOffset
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.StartTime.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Status.get -> JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.BuildRunOutput.Status.set -> void
+JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.BuildStatus.Canceled = 3 -> JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.BuildStatus.Failed = 1 -> JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.BuildStatus.Skipped = 2 -> JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.BuildStatus.Success = 0 -> JD.Efcpt.Build.Tasks.Profiling.BuildStatus
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel.Error = 2 -> JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel.Info = 0 -> JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel.Warning = 1 -> JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Code.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Code.set -> void
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.DiagnosticMessage() -> void
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Level.get -> JD.Efcpt.Build.Tasks.Profiling.DiagnosticLevel
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Level.set -> void
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Message.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Message.set -> void
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Timestamp.get -> System.DateTimeOffset
+JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage.Timestamp.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ITaskTracker
+JD.Efcpt.Build.Tasks.Profiling.ITaskTracker.SetOutputs(System.Collections.Generic.Dictionary<string!, object?>! outputs) -> void
+JD.Efcpt.Build.Tasks.Profiling.JsonTimeSpanConverter
+JD.Efcpt.Build.Tasks.Profiling.JsonTimeSpanConverter.JsonTimeSpanConverter() -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Configuration.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Configuration.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Name.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Name.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Path.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.Path.set -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.ProjectInfo() -> void
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.TargetFramework.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.ProjectInfo.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Diagnostics.get -> System.Collections.Generic.List<JD.Efcpt.Build.Tasks.Profiling.DiagnosticMessage!>!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Diagnostics.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Duration.get -> System.TimeSpan
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Duration.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.EndTime.get -> System.DateTimeOffset?
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.EndTime.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Extensions.get -> System.Collections.Generic.Dictionary<string!, object?>?
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Extensions.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Initiator.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Initiator.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Inputs.get -> System.Collections.Generic.Dictionary<string!, object?>!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Inputs.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Metadata.get -> System.Collections.Generic.Dictionary<string!, object?>!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Metadata.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Name.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Name.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Outputs.get -> System.Collections.Generic.Dictionary<string!, object?>!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Outputs.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.StartTime.get -> System.DateTimeOffset
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.StartTime.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Status.get -> JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Status.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.TaskExecution() -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Type.get -> string!
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Type.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Version.get -> string?
+JD.Efcpt.Build.Tasks.Profiling.TaskExecution.Version.set -> void
+JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.Profiling.TaskStatus.Canceled = 3 -> JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.Profiling.TaskStatus.Failed = 1 -> JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.Profiling.TaskStatus.Skipped = 2 -> JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.Profiling.TaskStatus.Success = 0 -> JD.Efcpt.Build.Tasks.Profiling.TaskStatus
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.AllowCustomProviders.get -> bool
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.AllowCustomProviders.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ConnectionString.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.EfcptCustomProviders.get -> Microsoft.Build.Framework.ITaskItem![]!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.EfcptCustomProviders.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.OutputDir.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.OutputDir.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.Provider.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.Provider.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ProviderSearchPaths.get -> string![]!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.ProviderSearchPaths.set -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.QuerySchemaMetadata() -> void
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.SchemaFingerprint.get -> string!
+JD.Efcpt.Build.Tasks.QuerySchemaMetadata.SchemaFingerprint.set -> void
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.GeneratedDir.get -> string!
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.GeneratedDir.set -> void
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.RenameGeneratedFiles.RenameGeneratedFiles() -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ConnectionString.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.DacpacPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ExplicitDbContextName.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ExplicitDbContextName.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ResolveDbContextName() -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ResolvedDbContextName.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.ResolvedDbContextName.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.SqlProjPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.SqlProjPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveDbContextName.UseConnectionStringMode.get -> string!
+JD.Efcpt.Build.Tasks.ResolveDbContextName.UseConnectionStringMode.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.AutoDetectWarningLevel.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.AutoDetectWarningLevel.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ConfigOverride.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ConfigOverride.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.Configuration.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.Configuration.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ConnectionStringSourceSearchPaths.get -> Microsoft.Build.Framework.ITaskItem![]!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ConnectionStringSourceSearchPaths.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.DefaultsRoot.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.DefaultsRoot.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.DumpResolvedInputs.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.DumpResolvedInputs.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAppConfig.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAppConfig.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAppSettings.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAppSettings.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsRegion.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsRegion.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsSecretId.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsSecretId.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsSecretJsonKey.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptAwsSecretJsonKey.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionString.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringEnvVar.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringEnvVar.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringName.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringName.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringSource.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptConnectionStringSource.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultSecretName.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultSecretName.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultSecretVersion.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultSecretVersion.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultUri.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.EfcptKeyVaultUri.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.IsUsingDefaultConfig.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.IsUsingDefaultConfig.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.OfflineMode.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.OfflineMode.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.OutputDir.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.OutputDir.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProbeSolutionDir.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProbeSolutionDir.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectDirectory.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectFullPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectFullPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectReferences.get -> Microsoft.Build.Framework.ITaskItem![]!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ProjectReferences.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.RenamingOverride.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.RenamingOverride.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolveSqlProjAndInputs() -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedConfigPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedConnectionString.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedRenamingPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedRenamingPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedTemplateDir.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.ResolvedTemplateDir.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SolutionDir.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SolutionDir.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SolutionPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SolutionPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SqlProjOverride.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SqlProjOverride.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SqlProjPath.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.SqlProjPath.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.TemplateDirOverride.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.TemplateDirOverride.set -> void
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.UseConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.UseConnectionString.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt
+JD.Efcpt.Build.Tasks.RunEfcpt.AutoAcquireTool.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.AutoAcquireTool.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ConfigPath.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ConnectionString.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.DacpacPath.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.DacpacPath.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.DotNetExe.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.DotNetExe.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.OfflineMode.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.OfflineMode.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.OutputDir.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.OutputDir.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.Provider.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.Provider.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.RenamingPath.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.RenamingPath.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.RunEfcpt() -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.TargetFramework.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.TemplateDir.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.TemplateDir.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolCommand.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolCommand.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolMode.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolMode.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolPackageId.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolPackageId.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolPath.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolPath.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolRestore.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolRestore.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolVersion.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.ToolVersion.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.UseConnectionStringMode.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.UseConnectionStringMode.set -> void
+JD.Efcpt.Build.Tasks.RunEfcpt.WorkingDirectory.get -> string!
+JD.Efcpt.Build.Tasks.RunEfcpt.WorkingDirectory.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage
+JD.Efcpt.Build.Tasks.RunSqlPackage.ConnectionString.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ConnectionString.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.DotNetExe.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.DotNetExe.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ExtractTarget.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ExtractTarget.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ExtractedPath.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ExtractedPath.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.RunSqlPackage() -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.TargetDirectory.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.TargetDirectory.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.TargetFramework.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolPath.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolPath.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolRestore.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolRestore.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolVersion.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.ToolVersion.set -> void
+JD.Efcpt.Build.Tasks.RunSqlPackage.WorkingDirectory.get -> string!
+JD.Efcpt.Build.Tasks.RunSqlPackage.WorkingDirectory.set -> void
+JD.Efcpt.Build.Tasks.Schema.CustomProviderException
+JD.Efcpt.Build.Tasks.Schema.CustomProviderException.Code.get -> string!
+JD.Efcpt.Build.Tasks.Schema.CustomProviderException.CustomProviderException(string! code, string! message) -> void
+JD.Efcpt.Build.Tasks.Schema.CustomProviderException.CustomProviderException(string! code, string! message, System.Exception? innerException) -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextName.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextName.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextNamespace.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextNamespace.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextOutputPath.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DbContextOutputPath.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DiscoverMultipleResultSets.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.DiscoverMultipleResultSets.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.EnableOnConfiguring.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.EnableOnConfiguring.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.GenerateMermaidDiagram.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.GenerateMermaidDiagram.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.GenerationType.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.GenerationType.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.MergeDacpacs.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.MergeDacpacs.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.ModelNamespace.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.ModelNamespace.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.OutputPath.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.OutputPath.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.PreserveCasingWithRegex.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.PreserveCasingWithRegex.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RefreshObjectLists.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RefreshObjectLists.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RemoveDefaultSqlFromBool.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RemoveDefaultSqlFromBool.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RootNamespace.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.RootNamespace.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SerializeConfigProperties() -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SerializedProperties.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SerializedProperties.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SoftDeleteObsoleteFiles.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SoftDeleteObsoleteFiles.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SplitDbContext.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.SplitDbContext.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.T4TemplatePath.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.T4TemplatePath.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseAlternateResultSetDiscovery.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseAlternateResultSetDiscovery.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDataAnnotations.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDataAnnotations.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDatabaseNames.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDatabaseNames.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDatabaseNamesForRoutines.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDatabaseNamesForRoutines.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDateOnlyTimeOnly.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDateOnlyTimeOnly.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDecimalAnnotationForSprocs.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseDecimalAnnotationForSprocs.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseHierarchyId.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseHierarchyId.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseInflector.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseInflector.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseInternalAccessForRoutines.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseInternalAccessForRoutines.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseLegacyInflector.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseLegacyInflector.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseManyToManyEntity.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseManyToManyEntity.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNoNavigations.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNoNavigations.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNodaTime.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNodaTime.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNullableReferenceTypes.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseNullableReferenceTypes.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UsePrefixNavigationNaming.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UsePrefixNavigationNaming.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSchemaFolders.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSchemaFolders.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSchemaNamespaces.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSchemaNamespaces.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSpatial.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseSpatial.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseT4.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseT4.set -> void
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseT4Split.get -> string!
+JD.Efcpt.Build.Tasks.SerializeConfigProperties.UseT4Split.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ConfigPath.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.LogVerbosity.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.LogVerbosity.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.OutputDir.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.OutputDir.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ProjectDirectory.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ProjectDirectory.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ProjectPath.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.ProjectPath.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.RenamingPath.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.RenamingPath.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StageEfcptInputs() -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedConfigPath.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedConfigPath.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedRenamingPath.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedRenamingPath.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedTemplateDir.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.StagedTemplateDir.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TargetFramework.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TargetFramework.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TemplateDir.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TemplateDir.set -> void
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TemplateOutputDir.get -> string!
+JD.Efcpt.Build.Tasks.StageEfcptInputs.TemplateOutputDir.set -> void
+const JD.Efcpt.Build.Tasks.Schema.CustomProviderException.AssemblyLoadFailedCode = "JD0018" -> string!
+const JD.Efcpt.Build.Tasks.Schema.CustomProviderException.CollidesWithBuiltInCode = "JD0019" -> string!
+const JD.Efcpt.Build.Tasks.Schema.CustomProviderException.MisconfiguredRegistrationCode = "JD0041" -> string!
+const JD.Efcpt.Build.Tasks.Schema.CustomProviderException.NoAdapterFoundCode = "JD0040" -> string!
+const JD.Efcpt.Build.Tasks.Schema.CustomProviderException.NotAllowedCode = "JD0017" -> string!
+override JD.Efcpt.Build.Tasks.AddSqlFileWarnings.Execute() -> bool
+override JD.Efcpt.Build.Tasks.ApplyConfigOverrides.Execute() -> bool
+override JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.CheckSdkVersion.Execute() -> bool
+override JD.Efcpt.Build.Tasks.ComputeFingerprint.Execute() -> bool
+override JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.GetHashCode() -> int
+override JD.Efcpt.Build.Tasks.DetectSqlProject.Execute() -> bool
+override JD.Efcpt.Build.Tasks.EfcptDoctor.Execute() -> bool
+override JD.Efcpt.Build.Tasks.EnsureDacpacBuilt.Execute() -> bool
+override JD.Efcpt.Build.Tasks.FinalizeBuildProfiling.Execute() -> bool
+override JD.Efcpt.Build.Tasks.InitializeBuildProfiling.Execute() -> bool
+override JD.Efcpt.Build.Tasks.Profiling.JsonTimeSpanConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.TimeSpan
+override JD.Efcpt.Build.Tasks.Profiling.JsonTimeSpanConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.TimeSpan value, System.Text.Json.JsonSerializerOptions! options) -> void
+override JD.Efcpt.Build.Tasks.QuerySchemaMetadata.Execute() -> bool
+override JD.Efcpt.Build.Tasks.RenameGeneratedFiles.Execute() -> bool
+override JD.Efcpt.Build.Tasks.ResolveDbContextName.Execute() -> bool
+override JD.Efcpt.Build.Tasks.ResolveSqlProjAndInputs.Execute() -> bool
+override JD.Efcpt.Build.Tasks.RunEfcpt.Execute() -> bool
+override JD.Efcpt.Build.Tasks.RunSqlPackage.Execute() -> bool
+override JD.Efcpt.Build.Tasks.SerializeConfigProperties.Execute() -> bool
+override JD.Efcpt.Build.Tasks.StageEfcptInputs.Execute() -> bool
+static JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.operator !=(JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext left, JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.operator ==(JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext left, JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.operator !=(JD.Efcpt.Build.Tasks.Chains.FileResolutionContext left, JD.Efcpt.Build.Tasks.Chains.FileResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.operator ==(JD.Efcpt.Build.Tasks.Chains.FileResolutionContext left, JD.Efcpt.Build.Tasks.Chains.FileResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.operator !=(JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext left, JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.operator ==(JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext left, JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.DbContextNameGenerator.FromConnectionString(string? connectionString) -> string?
+static JD.Efcpt.Build.Tasks.DbContextNameGenerator.FromDacpac(string? dacpacPath) -> string?
+static JD.Efcpt.Build.Tasks.DbContextNameGenerator.FromSqlProject(string? sqlProjPath) -> string?
+static JD.Efcpt.Build.Tasks.DbContextNameGenerator.Generate(string? sqlProjPath, string? dacpacPath, string? connectionString) -> string!
+static JD.Efcpt.Build.Tasks.Decorators.ProfilingBehavior.ExecuteWithProfiling<T>(T! task, System.Func<JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext, bool>! coreLogic, JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext ctx) -> bool
+static JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.operator !=(JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext left, JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.operator ==(JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext left, JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext right) -> bool
+static JD.Efcpt.Build.Tasks.MessageLevelHelpers.Parse(string? value, JD.Efcpt.Build.Core.Logging.MessageLevel defaultValue) -> JD.Efcpt.Build.Core.Logging.MessageLevel
+static JD.Efcpt.Build.Tasks.MessageLevelHelpers.TryParse(string? value, out JD.Efcpt.Build.Core.Logging.MessageLevel result) -> bool
+static JD.Efcpt.Build.Tasks.Profiling.BuildProfilerManager.Complete(string! projectPath, string! outputPath) -> void
+static JD.Efcpt.Build.Tasks.Profiling.BuildProfilerManager.GetOrCreate(string! projectPath, bool enabled, string! projectName, string? targetFramework = null, string? configuration = null) -> JD.Efcpt.Build.Tasks.Profiling.BuildProfiler!
+static JD.Efcpt.Build.Tasks.Profiling.BuildProfilerManager.TryGet(string! projectPath) -> JD.Efcpt.Build.Tasks.Profiling.BuildProfiler?
+virtual JD.Efcpt.Build.Tasks.CheckSdkVersion.EmitVersionUpdateMessage() -> void
+~override JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Tasks.Chains.DirectoryResolutionContext.ToString() -> string
+~override JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Tasks.Chains.FileResolutionContext.ToString() -> string
+~override JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Tasks.Chains.ResourceResolutionContext.ToString() -> string
+~override JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.Equals(object obj) -> bool
+~override JD.Efcpt.Build.Tasks.Decorators.TaskExecutionContext.ToString() -> string

--- a/src/JD.Efcpt.Build.Tasks/PublicAPI.Unshipped.txt
+++ b/src/JD.Efcpt.Build.Tasks/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/JD.Efcpt.Build.Tasks/packages.lock.json
+++ b/src/JD.Efcpt.Build.Tasks/packages.lock.json
@@ -97,17 +97,6 @@
           "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
-        "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0",
-          "System.Memory": "4.6.3"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "10.0.4",
@@ -433,6 +422,18 @@
       "jd.efcpt.build.providers.abstractions": {
         "type": "Project"
       },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.17.1",
+        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0",
+          "System.Memory": "4.6.3"
+        }
+      },
       "Microsoft.NET.StringTools": {
         "type": "CentralTransitive",
         "requested": "[18.7.1, )",
@@ -482,6 +483,12 @@
           "System.Security.Cryptography.ProtectedData": "10.0.4"
         }
       },
+      "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[5.6.0, )",
+        "resolved": "5.6.0",
+        "contentHash": "W4kJGezNIKLzo0Ak5FAQDFvkMf2U7DtGL4THmHyRSApfKsKt5V+eX/bU0ZLKAt/uf9Bb2o1bi0YDKj/GRB/vYQ=="
+      },
       "Microsoft.Data.SqlClient": {
         "type": "Direct",
         "requested": "[6.1.4, )",
@@ -521,16 +528,6 @@
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
-        }
-      },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
-        "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -716,6 +713,17 @@
       "jd.efcpt.build.providers.abstractions": {
         "type": "Project"
       },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.17.1",
+        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+        }
+      },
       "Microsoft.NET.StringTools": {
         "type": "CentralTransitive",
         "requested": "[18.7.1, )",
@@ -781,16 +789,6 @@
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
-        }
-      },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
-        "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -976,6 +974,17 @@
       "jd.efcpt.build.providers.abstractions": {
         "type": "Project"
       },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.17.1",
+        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+        }
+      },
       "Microsoft.NET.StringTools": {
         "type": "CentralTransitive",
         "requested": "[18.7.1, )",
@@ -1041,16 +1050,6 @@
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
-        }
-      },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
-        "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -1235,6 +1234,17 @@
       },
       "jd.efcpt.build.providers.abstractions": {
         "type": "Project"
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.17.1",
+        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+        }
       },
       "Microsoft.NET.StringTools": {
         "type": "CentralTransitive",

--- a/src/JD.Efcpt.Cli/JD.Efcpt.Cli.csproj
+++ b/src/JD.Efcpt.Cli/JD.Efcpt.Cli.csproj
@@ -32,6 +32,13 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <!--
+    PublicApiAnalyzers (#191: PUBLIC-API-STABILITY) locks this assembly's public surface.
+    Single-TFM project (net8.0), so build/PublicApi.props applies unconditionally - no
+    PublicApiAnalyzerTfm needed.
+  -->
+  <Import Project="..\..\build\PublicApi.props" />
+
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>

--- a/src/JD.Efcpt.Cli/PublicAPI.Shipped.txt
+++ b/src/JD.Efcpt.Cli/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+JD.Efcpt.Cli.Commands.DoctorCommand
+JD.Efcpt.Cli.Commands.InitCommand
+JD.Efcpt.Cli.Logging.ConsoleBuildLog
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.ConsoleBuildLog() -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Detail(string! message) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Error(string! code, string! message) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Error(string! message) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Info(string! message) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Log(JD.Efcpt.Build.Core.Logging.MessageLevel level, string! message, string? code = null) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Verbose.get -> bool
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Verbose.init -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Warn(string! code, string! message) -> void
+JD.Efcpt.Cli.Logging.ConsoleBuildLog.Warn(string! message) -> void
+const JD.Efcpt.Cli.Commands.DoctorCommand.ExitNoViablePathAdvisory = 2 -> int
+const JD.Efcpt.Cli.Commands.DoctorCommand.ExitNoViablePathStrict = 1 -> int
+const JD.Efcpt.Cli.Commands.DoctorCommand.ExitUnexpectedError = 3 -> int
+const JD.Efcpt.Cli.Commands.DoctorCommand.ExitViable = 0 -> int
+static JD.Efcpt.Cli.Commands.DoctorCommand.Build() -> System.CommandLine.Command!
+static JD.Efcpt.Cli.Commands.DoctorCommand.Execute(JD.Efcpt.Cli.Logging.ConsoleBuildLog! log, JD.Efcpt.Build.Core.Diagnostics.DoctorInputs inputs, JD.Efcpt.Build.Core.Diagnostics.ISdkProbe! probe) -> int
+static JD.Efcpt.Cli.Commands.InitCommand.Build() -> System.CommandLine.Command!
+static JD.Efcpt.Cli.Commands.InitCommand.ExecuteAsync(JD.Efcpt.Cli.Logging.ConsoleBuildLog! log, string? outputDir, string? provider, string? dbContextName, string? rootNamespace, bool force, bool online, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!

--- a/src/JD.Efcpt.Cli/PublicAPI.Unshipped.txt
+++ b/src/JD.Efcpt.Cli/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary
- Added `Microsoft.CodeAnalysis.PublicApiAnalyzers` (5.6.0) + a complete `PublicAPI.Shipped.txt` baseline to the reusable, externally-consumable library projects: `JD.Efcpt.Build.Providers.Abstractions`, `JD.Efcpt.Build.Core`, `JD.Efcpt.Ide.Core`, `JD.Efcpt.Build.Tasks`, and `JD.Efcpt.Cli`.
- New shared `build/PublicApi.props` is explicitly imported per-project (not via `Directory.Build.props`), so only these five projects opt into the analyzer.
- For the `net472;net8.0;net9.0;net10.0` multi-targeted projects (Providers.Abstractions, Core, Tasks), the analyzer + `AdditionalFiles` are scoped to **net10.0 only** via a `PublicApiAnalyzerTfm` property, avoiding a per-TFM baseline that would otherwise churn on net472's polyfilled types / looser nullable annotations, while still locking the real cross-consumer surface once. `Ide.Core` (netstandard2.0) and `Cli` (net8.0) are single-TFM, so the props apply unconditionally.
- Baselines were generated mechanically: build each project with the analyzer active, collect every `RS0016` diagnostic's reported symbol from the build log, and populate `PublicAPI.Unshipped.txt`, then move that into `PublicAPI.Shipped.txt` as the v1.0-locked baseline (leaving `Unshipped.txt` with just the `#nullable enable` header).
- Baseline is complete: `dotnet build JD.Efcpt.Build.sln -c Release` and `-c Debug` both succeed with 0 errors under `TreatWarningsAsErrors=true`, across all TFMs.
- Confirmed the analyzer is actually engaged: temporarily added an unlisted public member to `StringExtensions` in Providers.Abstractions and rebuilt - it produced `error RS0016: Symbol '...SanityCheckUnlistedMember...' is not part of the declared public API`, failing the build. Reverted before committing.
- `JD.Efcpt.Build.Tasks` (831-member baseline) and `JD.Efcpt.Cli` (21-member baseline) were both included per the task's "attempt if it generates cleanly" guidance - both built clean on the first mechanical pass.
- Deliberately excluded two unrelated `packages.lock.json` diffs (`src/JD.Efcpt.Build`, `tests/JD.Efcpt.Build.Tests`) that a full-solution restore regenerates on `main` even without any of this PR's changes (pre-existing drift, confirmed by stashing and re-restoring on a clean checkout) - out of scope for #191.
- No `CLAUDE.md` exists anywhere in this repo, so the net10.0-scoping rationale is documented directly in `build/PublicApi.props` and in each importing `.csproj` via inline comments instead.

## Test plan
- [x] `dotnet build JD.Efcpt.Build.sln -c Release` - 0 errors, 6 pre-existing unrelated TFM-support warnings only
- [x] `dotnet build JD.Efcpt.Build.sln -c Debug` - 0 errors
- [x] `dotnet test JD.Efcpt.Build.sln --filter "Category!=Integration"` - 1233/1233 passed, 0 failed
- [x] Manual RS0016 sanity check confirms the analyzer is live (see above)

Part of #191 (v1.0 readiness).