### PR TITLE
ci: adopt NuGet trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,11 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -399,9 +401,15 @@ jobs:
             ./artifacts/*.snupkg
           generate_release_notes: true
 
+      - name: NuGet login
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: JerrettDavis
+
       - name: Push to NuGet.org
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           if [ -n "$NUGET_API_KEY" ]; then
             dotnet nuget push ./artifacts/*.nupkg \


### PR DESCRIPTION
## Summary
- bind the NuGet publishing workflow to the `production` GitHub environment
- request `id-token: write` where the NuGet publish job runs
- swap repository NuGet API key usage for `NuGet/login@v1` OIDC-based temporary credentials

## Real Behavior Proof
- Parsed the updated workflow YAML successfully after the transform.
- Verified each updated workflow now contains `environment: production`, `uses: NuGet/login@v1`, and `id-token: write`.
- What was not tested: a live nuget.org publish, because the automated browser session was not authenticated to nuget.org for trusted publishing policy creation.